### PR TITLE
FNMR@FMR metric.

### DIFF
--- a/examples/cars/configs/train_cars.yaml
+++ b/examples/cars/configs/train_cars.yaml
@@ -37,6 +37,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1]
   map_top_k: [5]
+  fmr_vals: [0.5, 0.1, 0.01, 0.001]
   return_only_main_category: True
   visualize_only_main_category: True
 

--- a/examples/cars/configs/train_cars.yaml
+++ b/examples/cars/configs/train_cars.yaml
@@ -37,7 +37,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1]
   map_top_k: [5]
-  fmr_vals: [0.5, 0.1, 0.01, 0.001]
+  fmr_vals: [1]
   return_only_main_category: True
   visualize_only_main_category: True
 

--- a/examples/cars/configs/val_cars.yaml
+++ b/examples/cars/configs/val_cars.yaml
@@ -27,7 +27,7 @@ metric_args:
   cmc_top_k: [1, 5]
   map_top_k: [5]
   precision_top_k: [5]
-  fmr_vals: [0.5, 0.1, 0.01, 0.001]
+  fmr_vals: [1]
   return_only_main_category: False
   visualize_only_main_category: True
 

--- a/examples/cars/configs/val_cars.yaml
+++ b/examples/cars/configs/val_cars.yaml
@@ -27,6 +27,7 @@ metric_args:
   cmc_top_k: [1, 5]
   map_top_k: [5]
   precision_top_k: [5]
+  fmr_vals: [0.5, 0.1, 0.01, 0.001]
   return_only_main_category: False
   visualize_only_main_category: True
 

--- a/examples/cub/configs/train_cub.yaml
+++ b/examples/cub/configs/train_cub.yaml
@@ -37,6 +37,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1]
   map_top_k: [5]
+  fmr_vals: [0.5, 0.1, 0.01, 0.001]
   return_only_main_category: True
   visualize_only_main_category: True
 

--- a/examples/cub/configs/train_cub.yaml
+++ b/examples/cub/configs/train_cub.yaml
@@ -37,7 +37,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1]
   map_top_k: [5]
-  fmr_vals: [0.5, 0.1, 0.01, 0.001]
+  fmr_vals: [1]
   return_only_main_category: True
   visualize_only_main_category: True
 

--- a/examples/cub/configs/val_cub.yaml
+++ b/examples/cub/configs/val_cub.yaml
@@ -27,7 +27,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1, 5]
   map_top_k: [5]
-  fmr_vals: [0.5, 0.1, 0.01, 0.001]
+  fmr_vals: [1]
   precision_top_k: [5]
   return_only_main_category: False
   visualize_only_main_category: True

--- a/examples/cub/configs/val_cub.yaml
+++ b/examples/cub/configs/val_cub.yaml
@@ -27,6 +27,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1, 5]
   map_top_k: [5]
+  fmr_vals: [0.5, 0.1, 0.01, 0.001]
   precision_top_k: [5]
   return_only_main_category: False
   visualize_only_main_category: True

--- a/examples/inshop/configs/train_inshop.yaml
+++ b/examples/inshop/configs/train_inshop.yaml
@@ -41,6 +41,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1]
   map_top_k: [5]
+  fmr_vals: [0.5, 0.1, 0.01, 0.001]
   return_only_main_category: True
   visualize_only_main_category: True
 

--- a/examples/inshop/configs/train_inshop.yaml
+++ b/examples/inshop/configs/train_inshop.yaml
@@ -41,7 +41,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1]
   map_top_k: [5]
-  fmr_vals: [0.5, 0.1, 0.01, 0.001]
+  fmr_vals: [1]
   return_only_main_category: True
   visualize_only_main_category: True
 

--- a/examples/inshop/configs/train_inshop_with_mlp.yaml
+++ b/examples/inshop/configs/train_inshop_with_mlp.yaml
@@ -41,6 +41,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1]
   map_top_k: [5]
+  fmr_vals: [0.5, 0.1, 0.01, 0.001]
   return_only_main_category: True
   visualize_only_main_category: True
 

--- a/examples/inshop/configs/train_inshop_with_mlp.yaml
+++ b/examples/inshop/configs/train_inshop_with_mlp.yaml
@@ -41,7 +41,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1]
   map_top_k: [5]
-  fmr_vals: [0.5, 0.1, 0.01, 0.001]
+  fmr_vals: [1]
   return_only_main_category: True
   visualize_only_main_category: True
 

--- a/examples/inshop/configs/val_inshop.yaml
+++ b/examples/inshop/configs/val_inshop.yaml
@@ -28,7 +28,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1, 5]
   map_top_k: [5]
-  fmr_vals: [0.5, 0.1, 0.01, 0.001]
+  fmr_vals: [1]
   precision_top_k: [5]
   return_only_main_category: True
   visualize_only_main_category: True

--- a/examples/inshop/configs/val_inshop.yaml
+++ b/examples/inshop/configs/val_inshop.yaml
@@ -28,6 +28,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1, 5]
   map_top_k: [5]
+  fmr_vals: [0.5, 0.1, 0.01, 0.001]
   precision_top_k: [5]
   return_only_main_category: True
   visualize_only_main_category: True

--- a/examples/sop/configs/train_sop.yaml
+++ b/examples/sop/configs/train_sop.yaml
@@ -41,6 +41,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1]
   map_top_k: [5]
+  fmr_vals: [0.5, 0.1, 0.01, 0.001]
   return_only_main_category: True
   visualize_only_main_category: True
 

--- a/examples/sop/configs/train_sop.yaml
+++ b/examples/sop/configs/train_sop.yaml
@@ -41,7 +41,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1]
   map_top_k: [5]
-  fmr_vals: [0.5, 0.1, 0.01, 0.001]
+  fmr_vals: [1]
   return_only_main_category: True
   visualize_only_main_category: True
 

--- a/examples/sop/configs/val_sop.yaml
+++ b/examples/sop/configs/val_sop.yaml
@@ -27,6 +27,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1, 5]
   map_top_k: [5]
+  fmr_vals: [0.5, 0.1, 0.01, 0.001]
   return_only_main_category: False
   visualize_only_main_category: True
 

--- a/examples/sop/configs/val_sop.yaml
+++ b/examples/sop/configs/val_sop.yaml
@@ -27,7 +27,7 @@ metric_args:
   metrics_to_exclude_from_visualization: [cmc,]
   cmc_top_k: [1, 5]
   map_top_k: [5]
-  fmr_vals: [0.5, 0.1, 0.01, 0.001]
+  fmr_vals: [1]
   return_only_main_category: False
   visualize_only_main_category: True
 

--- a/oml/functional/metrics.py
+++ b/oml/functional/metrics.py
@@ -255,10 +255,12 @@ def extract_pos_neg_dists(
         mask_to_ignore: Binary matrix to indicate that some of the elements in gallery cannot be used
                      as answers and must be ignored
     """
-    pos_dist = distances[mask_gt]
     if mask_to_ignore is not None:
-        neg_dist = distances[~mask_gt & ~mask_to_ignore]
+        mask_to_not_ignore = ~mask_to_ignore
+        pos_dist = distances[mask_gt & mask_to_not_ignore]
+        neg_dist = distances[~mask_gt & mask_to_not_ignore]
     else:
+        pos_dist = distances[mask_gt]
         neg_dist = distances[~mask_gt]
     return pos_dist, neg_dist
 

--- a/oml/functional/metrics.py
+++ b/oml/functional/metrics.py
@@ -56,6 +56,8 @@ def calc_retrieval_metrics(
         if top_k_arg:
             assert all([isinstance(x, int) and (x > 0) for x in top_k_arg])
 
+    assert all(0 <= x <= 100 for x in fmr_vals)
+
     if distances.shape != mask_gt.shape:
         raise ValueError(
             f"Distances matrix has the shape of {distances.shape}, "
@@ -228,9 +230,19 @@ def calc_fnmr_at_fmr(pos_dist: torch.Tensor, neg_dist: torch.Tensor, fmr_vals: T
         neg_dist: distances between samples from different classes
         fmr_vals: Values of ``fmr`` (measured in percents) for which we compute the corresponding ``FNMR``.
                   For example, if ``fmr_values`` is (20, 40) we will calculate ``FNMR@FMR=20`` and ``FNMR@FMR=40``
+    Returns:
+        Tensor of ``FNMR@FMR`` values.
 
     See:
+
+    `Biometrics Performance`_.
+
+    `BIOMETRIC RECOGNITION: A MODERN ERA FOR SECURITY`_.
+
+    .. _Biometrics Performance:
         https://en.wikipedia.org/wiki/Biometrics#Performance
+
+    .. _`BIOMETRIC RECOGNITION: A MODERN ERA FOR SECURITY`:
         https://www.researchgate.net/publication/50315614_BIOMETRIC_RECOGNITION_A_MODERN_ERA_FOR_SECURITY
 
     For instance, for the following distances arrays
@@ -256,6 +268,9 @@ def extract_pos_neg_dists(
         mask_gt: ``(i,j)`` element indicates if for i-th query j-th gallery is the correct prediction
         mask_to_ignore: Binary matrix to indicate that some of the elements in gallery cannot be used
                      as answers and must be ignored
+    Return:
+        pos_dist: Tensor of distances between samples from the same class
+        neg_dist: Tensor of distances between samples from diffetent classes
     """
     if mask_to_ignore is not None:
         mask_to_not_ignore = ~mask_to_ignore

--- a/oml/functional/metrics.py
+++ b/oml/functional/metrics.py
@@ -34,7 +34,8 @@ def calc_retrieval_metrics(
         cmc_top_k: Tuple of ``k`` values to calculate ``cmc@k`` (`Cumulative Matching Characteristic`)
         precision_top_k: Tuple of  ``k`` values to calculate ``precision@k``
         map_top_k: Tuple of ``k`` values to calculate ``map@k`` (`Mean Average Precision`)
-        fmr_vals: Tuple of ``fmr`` values to calculate ``fnmr@fmr`` (`False Non Match Rate at given False Match Rate`)
+        fmr_vals: Values of ``fmr`` (measured in percents) for which we compute the corresponding ``FNMR``.
+                  For example, if ``fmr_values`` is (20, 40) we will calculate ``FNMR@FMR=20`` and ``FNMR@FMR=40``
         reduce: If ``False`` return metrics for each query without averaging
         check_dataset_validity: Set ``True`` if you want to check that we have available answers in the gallery for
          each of the queries
@@ -225,7 +226,8 @@ def calc_fnmr_at_fmr(pos_dist: torch.Tensor, neg_dist: torch.Tensor, fmr_vals: T
     Args:
         pos_dist: distances between samples from the same class
         neg_dist: distances between samples from different classes
-        fmr_vals: the values of FMR (in per cent) for which FNMR is required to be evaluated
+        fmr_vals: Values of ``fmr`` (measured in percents) for which we compute the corresponding ``FNMR``.
+                  For example, if ``fmr_values`` is (20, 40) we will calculate ``FNMR@FMR=20`` and ``FNMR@FMR=40``
 
     See:
         https://en.wikipedia.org/wiki/Biometrics#Performance

--- a/oml/metrics/embeddings.py
+++ b/oml/metrics/embeddings.py
@@ -86,8 +86,8 @@ class EmbeddingMetrics(IMetricVisualisable):
             cmc_top_k: Values of ``k`` to compute ``CMC@k`` metrics
             precision_top_k: Values of ``k`` to compute ``Precision@k`` metrics
             map_top_k: Values of ``k`` to compute ``MAP@k`` metrics
-            fmr_vals: Values of fmr (measured in percents) for which we compute the corresponding FNMR.
-                      For example, if fmr_values = (20, 40) we will calculate FNMR@FMR=20 and FNMR@FMR=40
+            fmr_vals: Values of ``fmr`` (measured in percents) for which we compute the corresponding ``FNMR``.
+                      For example, if ``fmr_values`` is (20, 40) we will calculate ``FNMR@FMR=20`` and ``FNMR@FMR=40``
             categories_key: Key to take the samples' categories from the batches (if you have ones)
             postprocessor: Postprocessor which applies some techniques like query reranking
             metrics_to_exclude_from_visualization: Names of the metrics to exclude from the visualization. It will not

--- a/oml/metrics/embeddings.py
+++ b/oml/metrics/embeddings.py
@@ -66,6 +66,7 @@ class EmbeddingMetrics(IMetricVisualisable):
         cmc_top_k: Tuple[int, ...] = (5,),
         precision_top_k: Tuple[int, ...] = (5,),
         map_top_k: Tuple[int, ...] = (5,),
+        fmr_vals: Tuple[float, ...] = (0.1,),
         categories_key: Optional[str] = None,
         postprocessor: Optional[IPostprocessor] = None,
         metrics_to_exclude_from_visualization: Iterable[str] = (),
@@ -85,6 +86,7 @@ class EmbeddingMetrics(IMetricVisualisable):
             cmc_top_k: Values of ``k`` to compute ``CMC@k`` metrics
             precision_top_k: Values of ``k`` to compute ``Precision@k`` metrics
             map_top_k: Values of ``k`` to compute ``MAP@k`` metrics
+            fmr_vals: Values of ``fmr`` to compute ``FNMR@FMR`` metrics
             categories_key: Key to take the samples' categories from the batches (if you have ones)
             postprocessor: Postprocessor which applies some techniques like query reranking
             metrics_to_exclude_from_visualization: Names of the metrics to exclude from the visualization. It will not
@@ -104,6 +106,7 @@ class EmbeddingMetrics(IMetricVisualisable):
         self.cmc_top_k = cmc_top_k
         self.precision_top_k = precision_top_k
         self.map_top_k = map_top_k
+        self.fmr_vals = fmr_vals
 
         self.categories_key = categories_key
         self.postprocessor = postprocessor
@@ -117,7 +120,8 @@ class EmbeddingMetrics(IMetricVisualisable):
         self.visualize_only_main_category = visualize_only_main_category
         self.return_only_main_category = return_only_main_category
 
-        self.metrics_to_exclude_from_visualization = metrics_to_exclude_from_visualization
+        self.metrics_to_exclude_from_visualization = ["fnmr@fmr"]
+        self.metrics_to_exclude_from_visualization.extend(metrics_to_exclude_from_visualization)
         self.verbose = verbose
 
         self.keys_to_accumulate = [self.embeddings_key, self.is_query_key, self.is_gallery_key, self.labels_key]
@@ -169,6 +173,7 @@ class EmbeddingMetrics(IMetricVisualisable):
             "cmc_top_k": self.cmc_top_k,
             "precision_top_k": self.precision_top_k,
             "map_top_k": self.map_top_k,
+            "fmr_vals": self.fmr_vals,
         }
 
         metrics: TMetricsDict_ByLabels = dict()

--- a/oml/metrics/embeddings.py
+++ b/oml/metrics/embeddings.py
@@ -66,7 +66,7 @@ class EmbeddingMetrics(IMetricVisualisable):
         cmc_top_k: Tuple[int, ...] = (5,),
         precision_top_k: Tuple[int, ...] = (5,),
         map_top_k: Tuple[int, ...] = (5,),
-        fmr_vals: Tuple[float, ...] = (0.1,),
+        fmr_vals: Tuple[int, ...] = (1,),
         categories_key: Optional[str] = None,
         postprocessor: Optional[IPostprocessor] = None,
         metrics_to_exclude_from_visualization: Iterable[str] = (),
@@ -86,7 +86,7 @@ class EmbeddingMetrics(IMetricVisualisable):
             cmc_top_k: Values of ``k`` to compute ``CMC@k`` metrics
             precision_top_k: Values of ``k`` to compute ``Precision@k`` metrics
             map_top_k: Values of ``k`` to compute ``MAP@k`` metrics
-            fmr_vals: Values of ``fmr`` to compute ``FNMR@FMR`` metrics
+            fmr_vals: Values of ``fmr`` (measured in per cents) to compute ``FNMR@FMR`` metrics for
             categories_key: Key to take the samples' categories from the batches (if you have ones)
             postprocessor: Postprocessor which applies some techniques like query reranking
             metrics_to_exclude_from_visualization: Names of the metrics to exclude from the visualization. It will not
@@ -120,8 +120,7 @@ class EmbeddingMetrics(IMetricVisualisable):
         self.visualize_only_main_category = visualize_only_main_category
         self.return_only_main_category = return_only_main_category
 
-        self.metrics_to_exclude_from_visualization = ["fnmr@fmr"]
-        self.metrics_to_exclude_from_visualization.extend(metrics_to_exclude_from_visualization)
+        self.metrics_to_exclude_from_visualization = ["fnmr@fmr"] + list(metrics_to_exclude_from_visualization)
         self.verbose = verbose
 
         self.keys_to_accumulate = [self.embeddings_key, self.is_query_key, self.is_gallery_key, self.labels_key]

--- a/oml/metrics/embeddings.py
+++ b/oml/metrics/embeddings.py
@@ -86,7 +86,8 @@ class EmbeddingMetrics(IMetricVisualisable):
             cmc_top_k: Values of ``k`` to compute ``CMC@k`` metrics
             precision_top_k: Values of ``k`` to compute ``Precision@k`` metrics
             map_top_k: Values of ``k`` to compute ``MAP@k`` metrics
-            fmr_vals: Values of ``fmr`` (measured in per cents) to compute ``FNMR@FMR`` metrics for
+            fmr_vals: Values of fmr (measured in percents) for which we compute the corresponding FNMR.
+                      For example, if fmr_values = (20, 40) we will calculate FNMR@FMR=20 and FNMR@FMR=40
             categories_key: Key to take the samples' categories from the batches (if you have ones)
             postprocessor: Postprocessor which applies some techniques like query reranking
             metrics_to_exclude_from_visualization: Names of the metrics to exclude from the visualization. It will not

--- a/tests/test_oml/test_functional/test_metrics/test_cmc_metric_old.py
+++ b/tests/test_oml/test_functional/test_metrics/test_cmc_metric_old.py
@@ -38,26 +38,27 @@ EPS = 1e-4
 
 TEST_DATA_SIMPLE = (
     # (distance_matrix, mask_gt,  topk, expected_value)
-    (torch.tensor([[1, 2], [2, 1]]), torch.tensor([[0, 1], [1, 0]]), 1, 0.0),
-    (torch.tensor([[0, 0.5], [0.0, 0.5]]), torch.tensor([[0, 1], [1, 0]]), 1, 0.5),
-    (torch.tensor([[0, 0.5], [0.0, 0.5]]), torch.tensor([[0, 1], [1, 0]]), 2, 1),
+    (torch.tensor([[1, 2], [2, 1]]), torch.tensor([[0, 1], [1, 0]], dtype=torch.bool), 1, 0.0),
+    (torch.tensor([[0, 0.5], [0.0, 0.5]]), torch.tensor([[0, 1], [1, 0]], dtype=torch.bool), 1, 0.5),
+    (torch.tensor([[0, 0.5], [0.0, 0.5]]), torch.tensor([[0, 1], [1, 0]], dtype=torch.bool), 2, 1),
     (
         torch.tensor([[1, 0.5, 0.2], [2, 3, 4], [0.4, 3, 4]]),
-        torch.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+        torch.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=torch.bool),
         2,
         1 / 3,
     ),
-    (torch.randn((10, 10)), torch.ones((10, 10)), 1, 1),
+    (torch.randn((10, 10)), torch.ones((10, 10), dtype=torch.bool), 1, 1),
 )
 
 TEST_DATA_LESS_SMALL = (
-    (torch.rand((10, 10)) + torch.tril(torch.ones((10, 10))), torch.eye(10), i, i / 10) for i in range(1, 10)
+    (torch.rand((10, 10)) + torch.tril(torch.ones((10, 10))), torch.eye(10, dtype=torch.bool), i, i / 10)
+    for i in range(1, 10)
 )
 
 TEST_DATA_GREATER_SMALL = (
     (
         torch.rand((10, 10)) + torch.triu(torch.ones((10, 10)), diagonal=1),
-        torch.eye(10),
+        torch.eye(10, dtype=torch.bool),
         i,
         i / 10,
     )
@@ -67,7 +68,7 @@ TEST_DATA_GREATER_SMALL = (
 TEST_DATA_LESS_BIG = (
     (
         torch.rand((100, 100)) + torch.tril(torch.ones((100, 100))),
-        torch.eye(100),
+        torch.eye(100, dtype=torch.bool),
         i,
         i / 100,
     )

--- a/tests/test_oml/test_functional/test_metrics/test_cmc_metric_old.py
+++ b/tests/test_oml/test_functional/test_metrics/test_cmc_metric_old.py
@@ -18,6 +18,7 @@ def cmc_score_count(distances: Tensor, mask_gt: Tensor, topk: int, mask_to_ignor
         cmc_top_k=(topk,),
         map_top_k=tuple(),
         precision_top_k=tuple(),
+        fmr_vals=tuple(),
     )
     return metrics["cmc"][topk]
 
@@ -38,27 +39,26 @@ EPS = 1e-4
 
 TEST_DATA_SIMPLE = (
     # (distance_matrix, mask_gt,  topk, expected_value)
-    (torch.tensor([[1, 2], [2, 1]]), torch.tensor([[0, 1], [1, 0]], dtype=torch.bool), 1, 0.0),
-    (torch.tensor([[0, 0.5], [0.0, 0.5]]), torch.tensor([[0, 1], [1, 0]], dtype=torch.bool), 1, 0.5),
-    (torch.tensor([[0, 0.5], [0.0, 0.5]]), torch.tensor([[0, 1], [1, 0]], dtype=torch.bool), 2, 1),
+    (torch.tensor([[1, 2], [2, 1]]), torch.tensor([[0, 1], [1, 0]]), 1, 0.0),
+    (torch.tensor([[0, 0.5], [0.0, 0.5]]), torch.tensor([[0, 1], [1, 0]]), 1, 0.5),
+    (torch.tensor([[0, 0.5], [0.0, 0.5]]), torch.tensor([[0, 1], [1, 0]]), 2, 1),
     (
         torch.tensor([[1, 0.5, 0.2], [2, 3, 4], [0.4, 3, 4]]),
-        torch.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=torch.bool),
+        torch.tensor([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
         2,
         1 / 3,
     ),
-    (torch.randn((10, 10)), torch.ones((10, 10), dtype=torch.bool), 1, 1),
+    (torch.randn((10, 10)), torch.ones((10, 10)), 1, 1),
 )
 
 TEST_DATA_LESS_SMALL = (
-    (torch.rand((10, 10)) + torch.tril(torch.ones((10, 10))), torch.eye(10, dtype=torch.bool), i, i / 10)
-    for i in range(1, 10)
+    (torch.rand((10, 10)) + torch.tril(torch.ones((10, 10))), torch.eye(10), i, i / 10) for i in range(1, 10)
 )
 
 TEST_DATA_GREATER_SMALL = (
     (
         torch.rand((10, 10)) + torch.triu(torch.ones((10, 10)), diagonal=1),
-        torch.eye(10, dtype=torch.bool),
+        torch.eye(10),
         i,
         i / 10,
     )
@@ -68,7 +68,7 @@ TEST_DATA_GREATER_SMALL = (
 TEST_DATA_LESS_BIG = (
     (
         torch.rand((100, 100)) + torch.tril(torch.ones((100, 100))),
-        torch.eye(100, dtype=torch.bool),
+        torch.eye(100),
         i,
         i / 100,
     )

--- a/tests/test_oml/test_functional/test_metrics/test_retrieval_metrics.py
+++ b/tests/test_oml/test_functional/test_metrics/test_retrieval_metrics.py
@@ -45,42 +45,6 @@ def naive_precision(positions: TPositions, k: int) -> torch.Tensor:
     return metric
 
 
-@pytest.fixture()
-def distances() -> torch.Tensor:
-    # fmt: off
-    distances = torch.tensor([[float("inf"), 1, 2, 3, 4],
-                              [1, float("inf"), 5, 6, 7],
-                              [2, 5, float("inf"), 8, 9],
-                              [3, 6, 8, float("inf"), 0],
-                              [4, 7, 9, 0, float("inf")]])
-    # fmt: on
-    return distances
-
-
-@pytest.fixture()
-def mask_gt() -> torch.Tensor:
-    # fmt: off
-    mask_gt = torch.tensor([[False, True, True, False, False],
-                            [True, False, True, False, False],
-                            [True, True, False, False, True],
-                            [False, False, False, False, True],
-                            [False, False, True, True, False]])
-    # fmt: on
-    return mask_gt
-
-
-@pytest.fixture()
-def mask_to_ignore() -> torch.Tensor:
-    # fmt: off
-    mask_to_ignore = torch.tensor([[True, False, False, False, False],
-                                   [False, True, False, False, False],
-                                   [False, False, True, False, False],
-                                   [False, False, False, True, False],
-                                   [False, False, False, False, True]])
-    # fmt: on
-    return mask_to_ignore
-
-
 def test_on_exact_case() -> None:
     """
     label 0:
@@ -201,13 +165,11 @@ def compare_metrics(
             assert torch.all(torch.isclose(values_expected, values_calculated, atol=1e-4)), [metric_name, k]
 
 
-def test_calc_fnmr_at_fmr(distances: torch.Tensor, mask_gt: torch.Tensor, mask_to_ignore: torch.Tensor) -> None:
+def test_calc_fnmr_at_fmr() -> None:
     fmr_vals = (10, 50)
-    pos_dist = distances[mask_gt]
-    neg_dist = distances[~mask_gt & ~mask_to_ignore]
+    pos_dist = torch.tensor([0, 0, 1, 1, 2, 2, 5, 5, 9, 9])
+    neg_dist = torch.tensor([3, 3, 4, 4, 6, 6, 7, 7, 8, 8])
     fnmr_at_fmr = calc_fnmr_at_fmr(pos_dist, neg_dist, fmr_vals)
-    # positive distances are 0 0 1 1 2 2 5 5 9 9
-    # negative distances are 3 3 4 4 6 6 7 7 8 8
     # 10 percentile of negative distances is 3 and
     # the number of positive distances that are greater than
     # or equal to 3 is 4 so FNMR@FMR(10%) is 4 / 10

--- a/tests/test_oml/test_metrics/test_embedding_metrics.py
+++ b/tests/test_oml/test_metrics/test_embedding_metrics.py
@@ -156,6 +156,7 @@ def run_retrieval_metrics(case) -> None:  # type: ignore
         cmc_top_k=top_k,
         precision_top_k=tuple(),
         map_top_k=tuple(),
+        fmr_vals=tuple(),
     )
 
     calc.setup(num_samples=num_samples)
@@ -189,6 +190,7 @@ def run_across_epochs(case1, case2) -> None:  # type: ignore
         cmc_top_k=top_k,
         precision_top_k=tuple(),
         map_top_k=tuple(),
+        fmr_vals=tuple(),
     )
 
     def epoch_case(batch_a, batch_b, ground_truth_metrics) -> None:  # type: ignore
@@ -251,6 +253,7 @@ def test_worst_k(case_for_distance_check) -> None:  # type: ignore
         cmc_top_k=(),
         precision_top_k=(),
         map_top_k=(2,),
+        fmr_vals=tuple(),
     )
 
     calc.setup(num_samples=num_samples)
@@ -274,6 +277,7 @@ def test_ready_to_vis(extra_keys: Tuple[str, ...]) -> None:  # type: ignore
         cmc_top_k=(1,),
         precision_top_k=(),
         map_top_k=(),
+        fmr_vals=tuple(),
     )
 
     assert calc.ready_to_visualize() or PATHS_KEY not in extra_keys


### PR DESCRIPTION
Add `calc_fnmr@fmr` function to functional/metrics.py and its call to `calc_retrieval_metrics`.
Add new parameter `fmr_vals` to `calc_retrieval_metrics`, `EmbeddingMetrics` and cofig files.
FNMR@FMR could't be used for data retrieval visualiztion, so it is added to `metrics_to_exclude_from_visualization` by default.
Add test for `calc_fnmr@fmr` and modify some other tests to work correctly with FNMR@FMR.

I had three test failed: `test_readme_was_built_correctly`, `test_code_blocks_in_readme` and `test_reduce_metrics` which is marked as it could be failed. The problem with `test_code_blocks_in_readme` is that I have just one GPU, so maybe it worth to be marked as it could be failed too. And as for `test_readme_was_built_correctly` I don't know what's wrong, because I didn't change readme files.