### PR TITLE
Fix lru and don't force to have both train and val splits for ConfigAPI

### DIFF
--- a/oml/datasets/base.py
+++ b/oml/datasets/base.py
@@ -50,7 +50,7 @@ class BaseDataset(Dataset):
         transform: Optional[TTransforms] = None,
         dataset_root: Optional[Union[str, Path]] = None,
         f_imread: TImReader = imread_cv2,
-        cache_size: int = 100_000,
+        cache_size: Optional[int] = 100_000,
         input_tensors_key: str = INPUT_TENSORS_KEY,
         labels_key: str = LABELS_KEY,
         paths_key: str = PATHS_KEY,
@@ -112,7 +112,7 @@ class BaseDataset(Dataset):
         self.df = df
         self.transform = transform if transform else get_transforms("norm_albu")
         self.f_imread = f_imread
-        self.read_bytes_image_cached = lru_cache(maxsize=cache_size)(self._read_bytes_image)
+        self.read_bytes_image_cached = lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
 
         available_augs_types = (albu.Compose, torchvision.transforms.Compose)
         assert isinstance(self.transform, available_augs_types), f"Type of transforms must be in {available_augs_types}"
@@ -218,7 +218,7 @@ class DatasetQueryGallery(BaseDataset, IDatasetQueryGallery):
         dataset_root: Optional[Union[str, Path]] = None,
         transform: Optional[albu.Compose] = None,
         f_imread: TImReader = imread_cv2,
-        cache_size: int = 100_000,
+        cache_size: Optional[int] = 100_000,
         input_tensors_key: str = INPUT_TENSORS_KEY,
         labels_key: str = LABELS_KEY,
         paths_key: str = PATHS_KEY,
@@ -264,7 +264,7 @@ def get_retrieval_datasets(
     f_imread_train: Optional[TImReader] = None,
     f_imread_val: Optional[TImReader] = None,
     dataframe_name: str = "df.csv",
-    cache_size: int = 100_000,
+    cache_size: Optional[int] = 100_000,
     verbose: bool = True,
 ) -> Tuple[DatasetWithLabels, DatasetQueryGallery]:
     df = pd.read_csv(dataset_root / dataframe_name, index_col=False)

--- a/oml/datasets/base.py
+++ b/oml/datasets/base.py
@@ -112,7 +112,9 @@ class BaseDataset(Dataset):
         self.df = df
         self.transform = transform if transform else get_transforms("norm_albu")
         self.f_imread = f_imread
-        self.read_bytes_image_cached = lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
+        self.read_bytes_image_cached = (
+            lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
+        )
 
         available_augs_types = (albu.Compose, torchvision.transforms.Compose)
         assert isinstance(self.transform, available_augs_types), f"Type of transforms must be in {available_augs_types}"

--- a/oml/datasets/base.py
+++ b/oml/datasets/base.py
@@ -127,7 +127,7 @@ class BaseDataset(Dataset):
     def __getitem__(self, idx: int) -> Dict[str, Any]:
         row = self.df.iloc[idx]
 
-        img_bytes = self.read_bytes_image_cached(row[PATHS_COLUMN])
+        img_bytes = self.read_bytes_image_cached(row[PATHS_COLUMN])  # type: ignore
         img = self.f_imread(img_bytes)
 
         im_h, im_w = img.shape[:2] if isinstance(img, np.ndarray) else img.size[::-1]

--- a/oml/datasets/base.py
+++ b/oml/datasets/base.py
@@ -112,7 +112,7 @@ class BaseDataset(Dataset):
         self.df = df
         self.transform = transform if transform else get_transforms("norm_albu")
         self.f_imread = f_imread
-        self.read_bytes_image_cached = (
+        self.read_bytes_image = (
             lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
         )
 
@@ -127,7 +127,7 @@ class BaseDataset(Dataset):
     def __getitem__(self, idx: int) -> Dict[str, Any]:
         row = self.df.iloc[idx]
 
-        img_bytes = self.read_bytes_image_cached(row[PATHS_COLUMN])  # type: ignore
+        img_bytes = self.read_bytes_image(row[PATHS_COLUMN])  # type: ignore
         img = self.f_imread(img_bytes)
 
         im_h, im_w = img.shape[:2] if isinstance(img, np.ndarray) else img.size[::-1]

--- a/oml/datasets/list_dataset.py
+++ b/oml/datasets/list_dataset.py
@@ -48,7 +48,9 @@ class ListDataset(Dataset):
         self.filenames_list = filenames_list
         self.transform = transform
         self.f_imread = f_imread
-        self.read_bytes_image_cached = lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
+        self.read_bytes_image_cached = (
+            lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
+        )
         self.bboxes = bboxes
 
         self.input_tensors_key = input_tensors_key

--- a/oml/datasets/list_dataset.py
+++ b/oml/datasets/list_dataset.py
@@ -80,7 +80,7 @@ class ListDataset(Dataset):
 
     def __getitem__(self, idx: int) -> Dict[str, Any]:
         im_path = self.filenames_list[idx]
-        img_bytes = self.read_bytes_image_cached(im_path)
+        img_bytes = self.read_bytes_image_cached(im_path)  # type: ignore
         img = self.f_imread(img_bytes)
         if self.bboxes is not None:
             bbox = self.bboxes[idx]

--- a/oml/datasets/list_dataset.py
+++ b/oml/datasets/list_dataset.py
@@ -48,7 +48,7 @@ class ListDataset(Dataset):
         self.filenames_list = filenames_list
         self.transform = transform
         self.f_imread = f_imread
-        self.read_bytes_image_cached = (
+        self.read_bytes_image = (
             lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
         )
         self.bboxes = bboxes
@@ -80,7 +80,7 @@ class ListDataset(Dataset):
 
     def __getitem__(self, idx: int) -> Dict[str, Any]:
         im_path = self.filenames_list[idx]
-        img_bytes = self.read_bytes_image_cached(im_path)  # type: ignore
+        img_bytes = self.read_bytes_image(im_path)  # type: ignore
         img = self.f_imread(img_bytes)
         if self.bboxes is not None:
             bbox = self.bboxes[idx]

--- a/oml/datasets/list_dataset.py
+++ b/oml/datasets/list_dataset.py
@@ -27,7 +27,7 @@ class ListDataset(Dataset):
         transform: TTransforms = get_normalisation_torch(),
         f_imread: TImReader = imread_cv2,
         input_tensors_key: str = INPUT_TENSORS_KEY,
-        cache_size: int = 100_000,
+        cache_size: Optional[int] = 100_000,
         index_key: str = INDEX_KEY,
     ):
         """
@@ -48,7 +48,7 @@ class ListDataset(Dataset):
         self.filenames_list = filenames_list
         self.transform = transform
         self.f_imread = f_imread
-        self.read_bytes_image_cached = lru_cache(maxsize=cache_size)(self._read_bytes_image)
+        self.read_bytes_image_cached = lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
         self.bboxes = bboxes
 
         self.input_tensors_key = input_tensors_key

--- a/oml/datasets/pairs.py
+++ b/oml/datasets/pairs.py
@@ -69,7 +69,7 @@ class ImagePairsDataset(IPairsDataset):
         pair_1st_key: str = PAIR_1ST_KEY,
         pair_2nd_key: str = PAIR_2ND_KEY,
         index_key: str = INDEX_KEY,
-        cache_size: int = 100_000,
+        cache_size: Optional[int] = 100_000,
     ):
         """
         Args:
@@ -94,7 +94,8 @@ class ImagePairsDataset(IPairsDataset):
         if transform is None:
             transform = get_normalisation_torch()
 
-        dataset_args = {"transform": transform, "f_imread": f_imread, "cache_size": cache_size // 2}
+        cache_size = cache_size // 2 if cache_size else None
+        dataset_args = {"transform": transform, "f_imread": f_imread, "cache_size": cache_size}
         self.dataset1 = ListDataset(paths1, bboxes=bboxes1, **dataset_args)
         self.dataset2 = ListDataset(paths2, bboxes=bboxes2, **dataset_args)
 

--- a/oml/datasets/triplet.py
+++ b/oml/datasets/triplet.py
@@ -59,7 +59,7 @@ class TriDataset(Dataset):
         self.transforms = transforms or get_normalisation_albu()
         assert isinstance(transforms, albu.Compose) or (transforms is None)
 
-        self.read_bytes_image_cached = (
+        self.read_bytes_image = (
             lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
         )
 
@@ -73,7 +73,7 @@ class TriDataset(Dataset):
             return fin.read()
 
     def get_image(self, path: Union[Path, str]) -> np.ndarray:
-        image_bytes = self.read_bytes_image_cached(path)  # type: ignore
+        image_bytes = self.read_bytes_image(path)  # type: ignore
         image = self.f_imread(image_bytes)
         return image
 

--- a/oml/datasets/triplet.py
+++ b/oml/datasets/triplet.py
@@ -73,7 +73,7 @@ class TriDataset(Dataset):
             return fin.read()
 
     def get_image(self, path: Union[Path, str]) -> np.ndarray:
-        image_bytes = self.read_bytes_image_cached(path)
+        image_bytes = self.read_bytes_image_cached(path)  # type: ignore
         image = self.f_imread(image_bytes)
         return image
 

--- a/oml/datasets/triplet.py
+++ b/oml/datasets/triplet.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from itertools import chain
 from pathlib import Path
 from random import sample
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union, Optional
 
 import albumentations as albu
 import numpy as np
@@ -28,7 +28,7 @@ class TriDataset(Dataset):
         transforms: albu.Compose,
         expand_ratio: float,
         f_imread: TImReader = imread_cv2,
-        cache_size: int = 50_000,
+        cache_size: Optional[int] = 50_000,
         index_key: str = INDEX_KEY,
     ):
         """
@@ -59,7 +59,7 @@ class TriDataset(Dataset):
         self.transforms = transforms or get_normalisation_albu()
         assert isinstance(transforms, albu.Compose) or (transforms is None)
 
-        self.read_bytes_image_cached = lru_cache(maxsize=cache_size)(self._read_bytes_image)
+        self.read_bytes_image_cached = lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
 
         self.index_key = index_key
 

--- a/oml/datasets/triplet.py
+++ b/oml/datasets/triplet.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from itertools import chain
 from pathlib import Path
 from random import sample
-from typing import Any, Dict, List, Tuple, Union, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import albumentations as albu
 import numpy as np
@@ -59,7 +59,9 @@ class TriDataset(Dataset):
         self.transforms = transforms or get_normalisation_albu()
         assert isinstance(transforms, albu.Compose) or (transforms is None)
 
-        self.read_bytes_image_cached = lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
+        self.read_bytes_image_cached = (
+            lru_cache(maxsize=cache_size)(self._read_bytes_image) if cache_size else self._read_bytes_image
+        )
 
         self.index_key = index_key
 

--- a/oml/utils/dataframe_format.py
+++ b/oml/utils/dataframe_format.py
@@ -40,25 +40,32 @@ def check_retrieval_dataframe_format(
 
     assert all(x in df.columns for x in OBLIGATORY_COLUMNS), df.columns
 
-    assert set(df[SPLIT_COLUMN]) == {"train", "validation"}, set(df[SPLIT_COLUMN])
+    assert set(df[SPLIT_COLUMN]).issubset({"train", "validation"}), set(df[SPLIT_COLUMN])
 
     mask_train = df[SPLIT_COLUMN] == "train"
-    assert pd.isna(df[IS_QUERY_COLUMN][mask_train].unique()[0]), df[IS_QUERY_COLUMN][mask_train].unique()
-    assert pd.isna(df[IS_GALLERY_COLUMN][mask_train].unique()[0]), df[IS_GALLERY_COLUMN][mask_train].unique()
+
+    if mask_train.sum() > 0:
+        q_train_vals = df[IS_QUERY_COLUMN][mask_train].unique()
+        assert pd.isna(q_train_vals[0]) and len(q_train_vals) == 1, q_train_vals
+        g_train_vals = df[IS_GALLERY_COLUMN][mask_train].unique()
+        assert pd.isna(g_train_vals[0]) and len(g_train_vals) == 1, g_train_vals
 
     val_mask = ~mask_train
 
-    for split_field in [IS_QUERY_COLUMN, IS_GALLERY_COLUMN]:
-        unq_values = set(df[split_field][val_mask])
-        assert unq_values in [{False}, {True}, {False, True}]
+    if val_mask.sum() > 0:
+        for split_field in [IS_QUERY_COLUMN, IS_GALLERY_COLUMN]:
+            unq_values = set(df[split_field][val_mask])
+            assert unq_values in [{False}, {True}, {False, True}], unq_values
+        assert all(
+            ((df[IS_QUERY_COLUMN][val_mask].astype(bool)) | df[IS_GALLERY_COLUMN][val_mask].astype(bool)).to_list()
+        )
 
     assert df[LABELS_COLUMN].dtypes == int
-
-    assert all(((df[IS_QUERY_COLUMN][val_mask].astype(bool)) | df[IS_GALLERY_COLUMN][val_mask].astype(bool)).to_list())
 
     # we explicitly put ==True here because of Nones
     labels_query = set(df[LABELS_COLUMN][df[IS_QUERY_COLUMN] == True])  # noqa
     labels_gallery = set(df[LABELS_COLUMN][df[IS_GALLERY_COLUMN] == True])  # noqa
+    # raise ValueError([labels_query, labels_gallery])
     assert labels_query.intersection(labels_gallery) == labels_query
 
     if dataset_root is None:

--- a/oml/utils/dataframe_format.py
+++ b/oml/utils/dataframe_format.py
@@ -65,7 +65,6 @@ def check_retrieval_dataframe_format(
     # we explicitly put ==True here because of Nones
     labels_query = set(df[LABELS_COLUMN][df[IS_QUERY_COLUMN] == True])  # noqa
     labels_gallery = set(df[LABELS_COLUMN][df[IS_GALLERY_COLUMN] == True])  # noqa
-    # raise ValueError([labels_query, labels_gallery])
     assert labels_query.intersection(labels_gallery) == labels_query
 
     if dataset_root is None:

--- a/tests/test_oml/test_utils/test_dataframe_format.py
+++ b/tests/test_oml/test_utils/test_dataframe_format.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+from typing import Tuple
+from uuid import uuid4
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from oml.const import (
+    IS_GALLERY_COLUMN,
+    IS_QUERY_COLUMN,
+    LABELS_COLUMN,
+    MOCK_DATASET_PATH,
+    OBLIGATORY_COLUMNS,
+    SPLIT_COLUMN,
+)
+from oml.utils.dataframe_format import check_retrieval_dataframe_format
+from oml.utils.download_mock_dataset import download_mock_dataset
+
+TDFrames = Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]
+
+
+@pytest.fixture()
+def mock_dfs() -> TDFrames:
+    df_train, df_val = download_mock_dataset(MOCK_DATASET_PATH)
+    df = pd.concat([df_train, df_val], ignore_index=True).reset_index(drop=True)
+    return df_train, df_val, df
+
+
+@pytest.mark.skip()
+def test_mock_df_is_valid(mock_dfs: TDFrames) -> None:
+    _, _, df = mock_dfs
+    check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+
+@pytest.mark.skip()
+def test_independent_splits(mock_dfs: TDFrames) -> None:
+    df_train, df_val, _ = mock_dfs
+    check_retrieval_dataframe_format(df_train, dataset_root=MOCK_DATASET_PATH)
+    check_retrieval_dataframe_format(df_val, dataset_root=MOCK_DATASET_PATH)
+
+
+@pytest.mark.skip()
+def test_no_obligatory_cols(mock_dfs: TDFrames) -> None:
+    _, _, df = mock_dfs
+    for col in OBLIGATORY_COLUMNS:
+        df_copy = df.copy()
+        df_copy.drop(columns=[col], inplace=True)
+        with pytest.raises(AssertionError):
+            check_retrieval_dataframe_format(df_copy, dataset_root=MOCK_DATASET_PATH)
+
+
+@pytest.mark.skip()
+def test_wrong_splits(mock_dfs: TDFrames) -> None:
+    _, _, df = mock_dfs
+    df = df.copy()
+    df.loc[0, SPLIT_COLUMN] = str(uuid4())
+    with pytest.raises(AssertionError):
+        check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+
+@pytest.mark.skip()
+def test_train_qg_not_none(mock_dfs: TDFrames) -> None:
+    df_train, _, _ = mock_dfs
+
+    with pytest.raises(AssertionError):
+        df = df_train.copy()
+        df.loc[0, IS_QUERY_COLUMN] = 1
+        check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+    with pytest.raises(AssertionError):
+        df = df_train.copy()
+        df.loc[0, IS_GALLERY_COLUMN] = 2
+        check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+
+@pytest.mark.skip()
+def test_val_qg_only_bool(mock_dfs: TDFrames) -> None:
+    _, df_val, _ = mock_dfs
+
+    with pytest.raises(AssertionError):
+        df = df_val.copy()
+        df.loc[0, IS_QUERY_COLUMN] = "asd"
+        check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+    with pytest.raises(AssertionError):
+        df = df_val.copy()
+        df.loc[0, IS_GALLERY_COLUMN] = 123
+        check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+    with pytest.raises(AssertionError):
+        df = df_val.copy()
+        df.loc[0, IS_GALLERY_COLUMN] = None
+        check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+
+@pytest.mark.skip()
+def test_q_without_g(mock_dfs: TDFrames) -> None:
+    _, df_val, _ = mock_dfs
+
+    with pytest.raises(AssertionError):
+        df = df_val.copy()
+        first_q_row = np.arange(len(df))[df[IS_QUERY_COLUMN] == True][0]
+        df.loc[first_q_row, LABELS_COLUMN] = max(df[LABELS_COLUMN]) + 1
+        check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+
+def test_images_not_found(mock_dfs: TDFrames) -> None:
+    _, _, df = mock_dfs
+    with pytest.raises(AssertionError):
+        check_retrieval_dataframe_format(df, dataset_root=Path(str(uuid4())))

--- a/tests/test_oml/test_utils/test_dataframe_format.py
+++ b/tests/test_oml/test_utils/test_dataframe_format.py
@@ -7,12 +7,17 @@ import pandas as pd
 import pytest
 
 from oml.const import (
+    BBOXES_COLUMNS,
     IS_GALLERY_COLUMN,
     IS_QUERY_COLUMN,
     LABELS_COLUMN,
     MOCK_DATASET_PATH,
     OBLIGATORY_COLUMNS,
     SPLIT_COLUMN,
+    X1_COLUMN,
+    X2_COLUMN,
+    Y1_COLUMN,
+    Y2_COLUMN,
 )
 from oml.utils.dataframe_format import check_retrieval_dataframe_format
 from oml.utils.download_mock_dataset import download_mock_dataset
@@ -27,20 +32,23 @@ def mock_dfs() -> TDFrames:
     return df_train, df_val, df
 
 
-@pytest.mark.skip()
+@pytest.fixture()
+def mock_with_bboxes() -> pd.DataFrame:
+    download_mock_dataset(MOCK_DATASET_PATH)
+    return pd.read_csv(MOCK_DATASET_PATH / "df_with_bboxes.csv")
+
+
 def test_mock_df_is_valid(mock_dfs: TDFrames) -> None:
     _, _, df = mock_dfs
     check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
 
 
-@pytest.mark.skip()
 def test_independent_splits(mock_dfs: TDFrames) -> None:
     df_train, df_val, _ = mock_dfs
     check_retrieval_dataframe_format(df_train, dataset_root=MOCK_DATASET_PATH)
     check_retrieval_dataframe_format(df_val, dataset_root=MOCK_DATASET_PATH)
 
 
-@pytest.mark.skip()
 def test_no_obligatory_cols(mock_dfs: TDFrames) -> None:
     _, _, df = mock_dfs
     for col in OBLIGATORY_COLUMNS:
@@ -50,7 +58,6 @@ def test_no_obligatory_cols(mock_dfs: TDFrames) -> None:
             check_retrieval_dataframe_format(df_copy, dataset_root=MOCK_DATASET_PATH)
 
 
-@pytest.mark.skip()
 def test_wrong_splits(mock_dfs: TDFrames) -> None:
     _, _, df = mock_dfs
     df = df.copy()
@@ -59,49 +66,46 @@ def test_wrong_splits(mock_dfs: TDFrames) -> None:
         check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
 
 
-@pytest.mark.skip()
 def test_train_qg_not_none(mock_dfs: TDFrames) -> None:
     df_train, _, _ = mock_dfs
 
+    df = df_train.copy()
+    df.loc[0, IS_QUERY_COLUMN] = 1
     with pytest.raises(AssertionError):
-        df = df_train.copy()
-        df.loc[0, IS_QUERY_COLUMN] = 1
         check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
 
+    df = df_train.copy()
+    df.loc[0, IS_GALLERY_COLUMN] = 2
     with pytest.raises(AssertionError):
-        df = df_train.copy()
-        df.loc[0, IS_GALLERY_COLUMN] = 2
         check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
 
 
-@pytest.mark.skip()
 def test_val_qg_only_bool(mock_dfs: TDFrames) -> None:
     _, df_val, _ = mock_dfs
 
+    df = df_val.copy()
+    df.loc[0, IS_QUERY_COLUMN] = "asd"
     with pytest.raises(AssertionError):
-        df = df_val.copy()
-        df.loc[0, IS_QUERY_COLUMN] = "asd"
         check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
 
+    df = df_val.copy()
+    df.loc[0, IS_GALLERY_COLUMN] = 123
     with pytest.raises(AssertionError):
-        df = df_val.copy()
-        df.loc[0, IS_GALLERY_COLUMN] = 123
         check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
 
+    df = df_val.copy()
+    df.loc[0, IS_GALLERY_COLUMN] = None
     with pytest.raises(AssertionError):
-        df = df_val.copy()
-        df.loc[0, IS_GALLERY_COLUMN] = None
         check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
 
 
-@pytest.mark.skip()
 def test_q_without_g(mock_dfs: TDFrames) -> None:
     _, df_val, _ = mock_dfs
 
+    df = df_val.copy()
+    first_q_row = np.arange(len(df))[df[IS_QUERY_COLUMN] == True][0]  # noqa
+    df.loc[first_q_row, LABELS_COLUMN] = max(df[LABELS_COLUMN]) + 1
     with pytest.raises(AssertionError):
-        df = df_val.copy()
-        first_q_row = np.arange(len(df))[df[IS_QUERY_COLUMN] == True][0]
-        df.loc[first_q_row, LABELS_COLUMN] = max(df[LABELS_COLUMN]) + 1
         check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
 
 
@@ -109,3 +113,46 @@ def test_images_not_found(mock_dfs: TDFrames) -> None:
     _, _, df = mock_dfs
     with pytest.raises(AssertionError):
         check_retrieval_dataframe_format(df, dataset_root=Path(str(uuid4())))
+
+
+def test_not_enough_bbox_columns(mock_with_bboxes: pd.DataFrame) -> None:
+    for col in BBOXES_COLUMNS:
+        df = mock_with_bboxes.copy()
+        df.drop(columns=[col], inplace=True)
+        with pytest.raises(AssertionError):
+            check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+
+def test_all_coords_none(mock_with_bboxes: pd.DataFrame) -> None:
+    df = mock_with_bboxes.copy()
+    for col in BBOXES_COLUMNS:
+        df[col] = np.nan
+    check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+
+def test_all_coords_not_none(mock_with_bboxes: pd.DataFrame) -> None:
+    for col in BBOXES_COLUMNS:
+        df = mock_with_bboxes.copy()
+        df[col] = np.nan
+        with pytest.raises(AssertionError):
+            check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+
+def test_not_empty_bbox(mock_with_bboxes: pd.DataFrame) -> None:
+    df = mock_with_bboxes.copy()
+    df.loc[0, X1_COLUMN] = df.loc[0, X2_COLUMN]
+    with pytest.raises(AssertionError):
+        check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+    df = mock_with_bboxes.copy()
+    df.loc[1, Y1_COLUMN] = df.loc[1, Y2_COLUMN] + 1
+    with pytest.raises(AssertionError):
+        check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)
+
+
+def test_not_negative_coords(mock_with_bboxes: pd.DataFrame) -> None:
+    for idx, col in enumerate(BBOXES_COLUMNS):
+        df = mock_with_bboxes.copy()
+        df.loc[idx, col] = -1
+        with pytest.raises(AssertionError):
+            check_retrieval_dataframe_format(df, dataset_root=MOCK_DATASET_PATH)


### PR DESCRIPTION
- Now we don't require to have validation and train split to use our API.
- Added tests for checking dataframe format.
- If `cache_size == 0` or `cache_size is None` we don't use `lru_cache`. It allows us to launch ConfigAPI with `spawn` multiprocessing start method.