### PR TITLE
Fixes #311

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.17.2, <1.23.1
 torch>=1.10, <=1.13.0
 torchvision>=0.11, <=0.14.0
-pytorch-lightning>=1.5.9, <=1.7.0  # refactor code, if you want newer versions
+pytorch-lightning>=1.5.9, <1.7.0  # refactor code, if you want newer versions
 albumentations>=1.0
 opencv-python>=4.1.1
 pillow>=8.2
@@ -12,7 +12,7 @@ grad-cam>=1.2
 
 omegaconf>=2.0.5, <2.3.0
 hydra-core>=1.2.0, <1.3.0
-neptune-client>=0.10.0
+neptune-client>=0.14.2, <1.0.0
 pytest>=7.2
 python-dotenv>=0.17.0
 validators>=0.18.0


### PR DESCRIPTION
**Reason for changes**: 
There were breaking changes in `neptune-1.0.0`, and `pytorch-lightning-1.7.0` looks for the new library name (`neptune` instead of `neptune-client`). Also, the minimum `neptune-client` requirement (0.10.0) was no longer supported by the Neptune server (needs `neptune-client>=0.14.2`). This PR constrains versions to prevent the above.