### PR TITLE
Pass device to torch.arange in implementation of NHardTripletsMiner

### DIFF
--- a/oml/miners/inbatch_nhard_tri.py
+++ b/oml/miners/inbatch_nhard_tri.py
@@ -126,7 +126,7 @@ class NHardTripletsMiner(ITripletsMinerInBatch):
         ids_p = []
         ids_n = []
 
-        for idx_anch in torch.arange(len(labels))[torch.logical_not(ignore_anchor_mask)]:
+        for idx_anch in torch.arange(len(labels), device=distmat.device)[torch.logical_not(ignore_anchor_mask)]:
             positives = hardest_positive[idx_anch_pos == idx_anch][self.positive_slice]
             negatives = hardest_negative[idx_anch_neg == idx_anch][self.negative_slice]
 


### PR DESCRIPTION
Hello!
This PR solves the following issue: https://github.com/OML-Team/open-metric-learning/issues/369