### PR TITLE
Feature/metrics/stable metrics

### DIFF
--- a/docs/source/oml/logging.rst
+++ b/docs/source/oml/logging.rst
@@ -17,7 +17,7 @@ There are two options to log your experiments when working with Pipelines:
 
   .. code-block:: bash
 
-      export NEPTUNE_API_TOKEN=your_token 
+      export NEPTUNE_API_TOKEN=your_token
       python train.py
 
 

--- a/oml/functional/metrics.py
+++ b/oml/functional/metrics.py
@@ -594,7 +594,7 @@ def _estimate_suitable_max_k(distances: Tensor, max_k: int) -> int:
         New value of ``max_k``
     """
     distances_tops, ii_top_k = torch.topk(distances, k=max_k + 1, largest=False)
-    n_same_distances = []
+    n_same_distances = [0]
     for i in torch.where(distances_tops[:, max_k - 1] == distances_tops[:, max_k])[0]:
         n_same_distances.append(
             torch.sum(distances[i, :] == distances_tops[i, max_k - 1])

--- a/oml/functional/metrics.py
+++ b/oml/functional/metrics.py
@@ -578,9 +578,12 @@ def _get_gt_tops(distances: Tensor, mask_gt: Tensor, all_k: List[int]) -> Tensor
     max_k = max(all_k)
     max_k = min(max_k, distances.shape[1] - 1)
     distances_tops, ii_top_k = torch.topk(distances, k=max_k + 1, largest=False)
-    while max_k < distances.shape[1] - 2 and torch.any(distances_tops[:, max_k - 1] == distances_tops[:, max_k]):
-        max_k += 1
-        distances_tops, ii_top_k = torch.topk(distances, k=max_k + 1, largest=False)
+    new_max_k = max_k
+    while new_max_k < distances.shape[1] - 2 and torch.any(
+        distances_tops[:, max_k - 1] == distances_tops[:, new_max_k]
+    ):
+        new_max_k += 1
+        distances_tops, ii_top_k = torch.topk(distances, k=new_max_k + 1, largest=False)
     gt_tops = take_2d(mask_gt, ii_top_k)
     gt_tops = _sort_gt_tops(gt_tops, distances_tops, all_k)
     return gt_tops

--- a/oml/functional/metrics.py
+++ b/oml/functional/metrics.py
@@ -562,7 +562,7 @@ def extract_pos_neg_dists(
 
 
 def _get_gt_tops(distances: Tensor, mask_gt: Tensor, all_k: List[int]) -> Tensor:
-    """Get ``gt_tops`` matrix for the given distances.
+    """Get ``gt_tops`` matrix with the ground truth for the top values of the given distances.
 
     Args:
         distances: Distance matrix with the shape of ``[query_size, gallery_size]``
@@ -576,7 +576,7 @@ def _get_gt_tops(distances: Tensor, mask_gt: Tensor, all_k: List[int]) -> Tensor
 
     """
     max_k = max(all_k)
-    max_k = min(max_k, distances.shape[1])
+    max_k = min(max_k, distances.shape[1] - 1)
     distances_tops, ii_top_k = torch.topk(distances, k=max_k + 1, largest=False)
     while max_k < distances.shape[1] - 2 and torch.any(distances_tops[:, max_k - 1] == distances_tops[:, max_k]):
         max_k += 1
@@ -603,9 +603,9 @@ def _sort_gt_tops(gt_tops: Tensor, distances_tops: Tensor, top_k: List[int]) -> 
         if k >= distances_tops.shape[1]:
             continue
         for i in torch.where(distances_tops[:, k - 1] == distances_tops[:, k])[0]:
-            same_distance_indeces = torch.where(distances_tops[i, :] == distances_tops[i, k - 1])[0]
-            low = same_distance_indeces[0]
-            up = same_distance_indeces[-1] + 1
+            same_distance_indices = torch.where(distances_tops[i, :] == distances_tops[i, k - 1])[0]
+            low = same_distance_indices[0]
+            up = same_distance_indices[-1] + 1
             gt_tops[i, low:up] = torch.sort(gt_tops[i, low:up])[0]
     return gt_tops
 

--- a/oml/functional/metrics.py
+++ b/oml/functional/metrics.py
@@ -617,7 +617,7 @@ def _sort_gt_tops(gt_tops: Tensor, distances_tops: Tensor, top_k: List[int]) -> 
     Returns:
         Sorted version of ``gt_tops``.
     """
-    for k in range(distances_tops.shape[1]):
+    for k in range(0, distances_tops.shape[1], 2):
         for i in torch.where(distances_tops[:, k - 1] == distances_tops[:, k])[0]:
             same_distance_indices = torch.where(distances_tops[i, :] == distances_tops[i, k - 1])[0]
             low = same_distance_indices[0]

--- a/tests/test_oml/test_functional/test_metrics/test_retrieval_metrics.py
+++ b/tests/test_oml/test_functional/test_metrics/test_retrieval_metrics.py
@@ -298,7 +298,8 @@ def test_calc_fnmr_at_fmr_check_params(fmr_vals: Tuple[int, ...]) -> None:
         calc_fnmr_at_fmr(pos_dist, neg_dist, fmr_vals)
 
 
-def test_retrieval_metrics_stability() -> None:
+@pytest.mark.parametrize("top_k", ((1,), (2,), (3,), (4,), (5,)))
+def test_retrieval_metrics_stability(top_k: Tuple[int]) -> None:
     distances = torch.tensor(
         [
             [1, 1, 1, 2, 3, 4],
@@ -321,7 +322,6 @@ def test_retrieval_metrics_stability() -> None:
         ],
         dtype=torch.int,
     )
-    top_k = (1, 2, 3, 4, 5)
     metrics = calc_retrieval_metrics(
         distances, mask_gt, cmc_top_k=top_k, precision_top_k=top_k, map_top_k=top_k, fmr_vals=tuple(), reduce=False
     )

--- a/tests/test_runs/test_ddp_cases/test_train_with_metrics.py
+++ b/tests/test_runs/test_ddp_cases/test_train_with_metrics.py
@@ -36,7 +36,7 @@ exp_file = PROJECT_ROOT / "tests/test_runs/test_ddp_cases/run_retrieval_experime
 
 @pytest.mark.parametrize("batch_size", [10, 19])
 @pytest.mark.parametrize("max_epochs", [2])
-@pytest.mark.parametrize("num_labels,atol", [(200, 5e-3), (1000, 2e-2)])
+@pytest.mark.parametrize("num_labels,atol", [(200, 8e-3), (1000, 2e-2)])
 def test_metrics_is_similar_in_ddp(num_labels: int, atol: float, batch_size: int, max_epochs: int) -> None:
     devices = (1, 2, 3)
     # We will compare metrics from same experiment but with different amount of devices. For this we aggregate


### PR DESCRIPTION
Introduce permutation stable version of the retrieval metrics. The idea is to sort `gt_tops` for which distances are the same, i.e. if `distances_tops` and `gt_tops` are

```python
distances_tops = [1, 2, 2, 2, 3]
gt_tops = [0, 1, 0, 1, 0]
```

then we need to obtain
```python
gt_tops = [0, 0, 1, 1, 0]
#             -------
#             sort gt_tops where there are multiple
#             distances of the same value
```

The code for the retrieval metrics itself doesn't change.