### PR TITLE
Temporarily turn on all tests (because of migration to torch 2.0)

### DIFF
--- a/.github/workflows/tests-workflow.yaml
+++ b/.github/workflows/tests-workflow.yaml
@@ -26,7 +26,7 @@ jobs:
         make docker_build RUNTIME=cpu
     - name: Short Tests OML
       run: |
-        make docker_short_tests RUNTIME=cpu WANDB_API_KEY=${{ secrets.WANDB_API_KEY }} NEPTUNE_API_TOKEN=${{ secrets.NEPTUNE_API_TOKEN }}
+        make docker_all_tests RUNTIME=cpu WANDB_API_KEY=${{ secrets.WANDB_API_KEY }} NEPTUNE_API_TOKEN=${{ secrets.NEPTUNE_API_TOKEN }}
 
   all_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Temprorary turn on all tests (because of migration to torch 2.0)