### PR TITLE
Handle sampler: null in config api

### DIFF
--- a/oml/lightning/pipelines/parser.py
+++ b/oml/lightning/pipelines/parser.py
@@ -150,7 +150,9 @@ def parse_scheduler_from_config(cfg: TCfg, optimizer: torch.optim.Optimizer) -> 
 
 
 def parse_sampler_from_config(cfg: TCfg, dataset: DatasetWithLabels) -> Optional[IBatchSampler]:
-    if (not dataset.categories_key) and cfg["sampler"]["name"] in SAMPLERS_CATEGORIES_BASED.keys():
+    if (not dataset.categories_key) and \
+       (cfg["sampler"] is not None) and \
+        cfg["sampler"]["name"] in SAMPLERS_CATEGORIES_BASED.keys():
         raise ValueError(
             "NOTE! You are trying to use Sampler which works with the information related"
             "to categories, but there is no <categories_key> in your Dataset."

--- a/tests/test_runs/test_pipelines/configs/train_with_bboxes.yaml
+++ b/tests/test_runs/test_pipelines/configs/train_with_bboxes.yaml
@@ -35,7 +35,9 @@ criterion:
 
 defaults:
   - optimizer: adam
-  - sampler: balance
+
+sampler: null
+bs_train: 6
 
 extractor:
   name: resnet


### PR DESCRIPTION
handle sampler = None logic while config parsing
rewrite test example to check that

For now, we don't push you to follow any predefined schema of issue, but ensure you've already read our contribution guide: https://open-metric-learning.readthedocs.io/en/latest/from_readme/contributing.html.
