### PR TITLE
Refactored loggers

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,8 @@ on:
       - main
 
 jobs:
-  short_tests:
+  # todo
+  xxx_tests:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     strategy:
@@ -31,7 +32,8 @@ jobs:
       run: |
         make run_short_tests
 
-  all_tests:
+  # todo
+  short_tests:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     strategy:
@@ -51,9 +53,10 @@ jobs:
         python3 -m pip install -r ci/requirements_optional.txt
         python3 -m pip install -e .
     - name: Running all tests
+      # todo
       run: |
         if [ "${{ matrix.python-version }}" == "3.8" ]; then
-          make run_all_tests WANDB_API_KEY=${{ secrets.WANDB_API_KEY }} NEPTUNE_API_TOKEN=${{ secrets.NEPTUNE_API_TOKEN }} DOWNLOAD_ZOO_IN_TESTS=yes
+          make run_all_tests WANDB_API_KEY=${{ secrets.WANDB_API_KEY }} NEPTUNE_API_TOKEN=${{ secrets.NEPTUNE_API_TOKEN }} DOWNLOAD_ZOO_IN_TESTS=no TEST_CLOUD_LOGGERS=yes
         else
           make run_all_tests WANDB_API_KEY=${{ secrets.WANDB_API_KEY }} NEPTUNE_API_TOKEN=${{ secrets.NEPTUNE_API_TOKEN }}
         fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,8 +11,7 @@ on:
 jobs:
   short_tests:
     runs-on: ubuntu-latest
-    # todo: put back 'pull_request'
-    if: github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
@@ -34,8 +33,7 @@ jobs:
 
   all_tests:
     runs-on: ubuntu-latest
-    # todo put back 'push'
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'push'
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
@@ -53,10 +51,9 @@ jobs:
         python3 -m pip install -r ci/requirements_optional.txt
         python3 -m pip install -e .
     - name: Running all tests
-      # todo
       run: |
         if [ "${{ matrix.python-version }}" == "3.8" ]; then
-          make run_all_tests WANDB_API_KEY=${{ secrets.WANDB_API_KEY }} NEPTUNE_API_TOKEN=${{ secrets.NEPTUNE_API_TOKEN }} DOWNLOAD_ZOO_IN_TESTS=no TEST_CLOUD_LOGGERS=yes
+          make run_all_tests WANDB_API_KEY=${{ secrets.WANDB_API_KEY }} NEPTUNE_API_TOKEN=${{ secrets.NEPTUNE_API_TOKEN }} DOWNLOAD_ZOO_IN_TESTS=yes TEST_CLOUD_LOGGERS=yes
         else
           make run_all_tests WANDB_API_KEY=${{ secrets.WANDB_API_KEY }} NEPTUNE_API_TOKEN=${{ secrets.NEPTUNE_API_TOKEN }}
         fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,8 +9,7 @@ on:
       - main
 
 jobs:
-  # todo
-  xxx_tests:
+  short_tests:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     strategy:
@@ -32,10 +31,10 @@ jobs:
       run: |
         make run_short_tests
 
-  # todo
-  short_tests:
+  all_tests:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    # todo put back 'push'
+    if: github.event_name == 'pull_request'
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,8 @@ on:
 jobs:
   short_tests:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # todo: put back 'pull_request'
+    if: github.event_name == 'push'
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ from oml.miners.inbatch_all_tri import AllTripletsMiner
 from oml.models import ViTExtractor
 from oml.samplers.balance import BalanceSampler
 from oml.utils.download_mock_dataset import download_mock_dataset
-from pytorch_lightning.loggers import NeptuneLogger, TensorBoardLogger, WandbLogger
+from oml.lightning.pipelines.logging import NeptunePipelineLogger, TensorBoardPipelineLogger, WandBPipelineLogger
 
 dataset_root = "mock_dataset/"
 df_train, df_val = download_mock_dataset(dataset_root)
@@ -413,15 +413,15 @@ val_loader = torch.utils.data.DataLoader(val_dataset, batch_size=4)
 metric_callback = MetricValCallback(metric=EmbeddingMetrics(extra_keys=[train_dataset.paths_key,]), log_images=True)
 
 # 1) Logging with Tensorboard
-logger = TensorBoardLogger(".")
+logger = TensorBoardPipelineLogger(".")
 
 # 2) Logging with Neptune
-# logger = NeptuneLogger(api_key="", project="", log_model_checkpoints=False)
+# logger = NeptunePipelineLogger(api_key="", project="", log_model_checkpoints=False)
 
 # 3) Logging with Weights and Biases
 # import os
 # os.environ["WANDB_API_KEY"] = ""
-# logger = WandbLogger(project="test_project", log_model=False)
+# logger = WandBPipelineLogger(project="test_project", log_model=False)
 
 # run
 pl_model = ExtractorModule(extractor, criterion, optimizer)

--- a/ci/requirements_optional.txt
+++ b/ci/requirements_optional.txt
@@ -1,4 +1,4 @@
 grad-cam==1.4.6
 jupyter>=1.0.0
-neptune-client>=0.14.2, <1.0.0
+neptune>=1.0.0, <1.10.1
 wandb>=0.15.4

--- a/docs/readme/examples_source/extractor/train_val_pl.md
+++ b/docs/readme/examples_source/extractor/train_val_pl.md
@@ -16,7 +16,7 @@ from oml.miners.inbatch_all_tri import AllTripletsMiner
 from oml.models import ViTExtractor
 from oml.samplers.balance import BalanceSampler
 from oml.utils.download_mock_dataset import download_mock_dataset
-from pytorch_lightning.loggers import NeptuneLogger, TensorBoardLogger, WandbLogger
+from oml.lightning.pipelines.logging import NeptunePipelineLogger, TensorBoardPipelineLogger, WandBPipelineLogger
 
 dataset_root = "mock_dataset/"
 df_train, df_val = download_mock_dataset(dataset_root)
@@ -37,15 +37,15 @@ val_loader = torch.utils.data.DataLoader(val_dataset, batch_size=4)
 metric_callback = MetricValCallback(metric=EmbeddingMetrics(extra_keys=[train_dataset.paths_key,]), log_images=True)
 
 # 1) Logging with Tensorboard
-logger = TensorBoardLogger(".")
+logger = TensorBoardPipelineLogger(".")
 
 # 2) Logging with Neptune
-# logger = NeptuneLogger(api_key="", project="", log_model_checkpoints=False)
+# logger = NeptunePipelineLogger(api_key="", project="", log_model_checkpoints=False)
 
 # 3) Logging with Weights and Biases
 # import os
 # os.environ["WANDB_API_KEY"] = ""
-# logger = WandbLogger(project="test_project", log_model=False)
+# logger = WandBPipelineLogger(project="test_project", log_model=False)
 
 # run
 pl_model = ExtractorModule(extractor, criterion, optimizer)

--- a/oml/interfaces/loggers.py
+++ b/oml/interfaces/loggers.py
@@ -6,11 +6,13 @@ from pytorch_lightning.loggers import Logger as LightningLogger
 from oml.const import TCfg
 
 
-class IPipelineLogger(LightningLogger):
-    @abstractmethod
-    def log_experiment_info(self, cfg: TCfg) -> None:
-        raise NotImplementedError()
-
+class IFigureLogger:
     @abstractmethod
     def log_figure(self, fig: plt.Figure, title: str, idx: int) -> None:
+        raise NotImplementedError()
+
+
+class IPipelineLogger(LightningLogger, IFigureLogger):
+    @abstractmethod
+    def log_pipeline_info(self, cfg: TCfg) -> None:
         raise NotImplementedError()

--- a/oml/interfaces/loggers.py
+++ b/oml/interfaces/loggers.py
@@ -1,0 +1,16 @@
+from abc import abstractmethod
+
+from matplotlib import pyplot as plt
+from pytorch_lightning.loggers import Logger as LightningLogger
+
+from oml.const import TCfg
+
+
+class IPipelineLogger(LightningLogger):
+    @abstractmethod
+    def log_experiment_info(self, cfg: TCfg) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def log_figure(self, fig: plt.Figure, title: str, idx: int) -> None:
+        raise NotImplementedError()

--- a/oml/lightning/callbacks/metric.py
+++ b/oml/lightning/callbacks/metric.py
@@ -2,18 +2,16 @@ from math import ceil
 from typing import Any, Optional
 
 import matplotlib.pyplot as plt
-import numpy as np
 import pytorch_lightning as pl
 from pytorch_lightning import Callback
-from pytorch_lightning.loggers import NeptuneLogger, TensorBoardLogger, WandbLogger
 from pytorch_lightning.utilities.types import STEP_OUTPUT
 from torch.utils.data import DataLoader
 
 from oml.const import LOG_IMAGE_FOLDER
 from oml.ddp.patching import check_loaders_is_patched, patch_dataloader_to_ddp
+from oml.interfaces.loggers import IPipelineLogger
 from oml.interfaces.metrics import IBasicMetric, IMetricDDP, IMetricVisualisable
 from oml.lightning.modules.ddp import ModuleDDP
-from oml.utils.images.images import figure_to_nparray
 from oml.utils.misc import flatten_dict
 
 
@@ -104,20 +102,9 @@ class MetricValCallback(Callback):
 
         for fig, metric_log_str in zip(*self.metric.visualize()):
             log_str = f"{LOG_IMAGE_FOLDER}/{metric_log_str}"
-            if isinstance(pl_module.logger, NeptuneLogger):
-                from neptune.new.types import File  # this is the optional dependency
 
-                pl_module.logger.experiment[log_str].log(File.as_image(fig))
-            elif isinstance(pl_module.logger, WandbLogger):
-                fig_img = figure_to_nparray(fig)
-                pl_module.logger.log_image(images=[fig_img], key=metric_log_str)
-            elif isinstance(pl_module.logger, TensorBoardLogger):
-                fig_img = figure_to_nparray(fig)
-                pl_module.logger.experiment.add_image(
-                    log_str, np.transpose(fig_img, (2, 0, 1)), pl_module.current_epoch
-                )
-            else:
-                raise ValueError(f"Logging with {type(pl_module.logger)} is not supported yet.")
+            assert isinstance(pl_module.logger, IPipelineLogger)
+            pl_module.logger.log_figure(fig=fig, title=log_str, idx=pl_module.current_epoch)
 
             plt.close(fig=fig)
 

--- a/oml/lightning/pipelines/logging.py
+++ b/oml/lightning/pipelines/logging.py
@@ -27,7 +27,7 @@ def prepare_tags(cfg: TCfg) -> List[str]:
 
 
 class NeptunePipelineLogger(NeptuneLogger, IPipelineLogger):
-    def log_experiment_info(self, cfg: TCfg) -> None:
+    def log_pipeline_info(self, cfg: TCfg) -> None:
         warnings.warn(
             "Unfortunately, in the case of using Neptune, you may experience that long experiments are "
             "stacked and not responding. It's not an issue on OML's side, so, we cannot fix it."
@@ -57,7 +57,7 @@ class NeptunePipelineLogger(NeptuneLogger, IPipelineLogger):
 
 
 class WandBPipelineLogger(WandbLogger, IPipelineLogger):
-    def log_experiment_info(self, cfg: TCfg) -> None:
+    def log_pipeline_info(self, cfg: TCfg) -> None:
         # this is the optional dependency
         import wandb
 
@@ -90,9 +90,12 @@ class WandBPipelineLogger(WandbLogger, IPipelineLogger):
 
 
 class TensorBoardPipelineLogger(TensorBoardLogger, IPipelineLogger):
-    def log_experiment_info(self, cfg: TCfg) -> None:
+    def log_pipeline_info(self, cfg: TCfg) -> None:
         pass
 
     def log_figure(self, fig: plt.Figure, title: str, idx: int) -> None:
         fig_img = figure_to_nparray(fig)
         self.experiment.add_image(title, np.transpose(fig_img, (2, 0, 1)), idx)
+
+
+__all__ = ["IPipelineLogger", "TensorBoardPipelineLogger", "WandBPipelineLogger", "NeptunePipelineLogger"]

--- a/oml/lightning/pipelines/logging.py
+++ b/oml/lightning/pipelines/logging.py
@@ -1,0 +1,98 @@
+import warnings
+from pathlib import Path
+from typing import Any, Dict, List
+
+import matplotlib.pyplot as plt
+import numpy as np
+from pytorch_lightning.loggers import NeptuneLogger, TensorBoardLogger, WandbLogger
+
+from oml.const import OML_PATH, TCfg
+from oml.interfaces.loggers import IPipelineLogger
+from oml.registry.transforms import save_transforms_as_files
+from oml.utils.images.images import figure_to_nparray
+from oml.utils.misc import dictconfig_to_dict, flatten_dict
+
+
+def prepare_config_to_logging(cfg: TCfg) -> Dict[str, Any]:
+    cwd = Path.cwd().name
+    flattened_dict = flatten_dict({**dictconfig_to_dict(cfg), **{"dir": cwd}}, sep="|")
+    return flattened_dict
+
+
+def prepare_tags(cfg: TCfg) -> List[str]:
+    cwd = Path.cwd().name
+    tags = list(cfg.get("tags", [])) + [cfg.get("postfix", "")] + [cwd]
+    tags = list(filter(lambda x: len(x) > 0, tags))
+    return tags
+
+
+class NeptunePipelineLogger(NeptuneLogger, IPipelineLogger):
+    def log_experiment_info(self, cfg: TCfg) -> None:
+        warnings.warn(
+            "Unfortunately, in the case of using Neptune, you may experience that long experiments are "
+            "stacked and not responding. It's not an issue on OML's side, so, we cannot fix it."
+        )
+        self.log_hyperparams(prepare_config_to_logging(cfg))
+
+        tags = prepare_tags(cfg)
+        self.run["sys/tags"].add(tags)
+
+        # log transforms as files
+        for key, transforms_file in save_transforms_as_files(cfg):
+            self.run[key].upload(transforms_file)
+
+        # log source code
+        source_files = list(map(lambda x: str(x), OML_PATH.glob("**/*.py"))) + list(
+            map(lambda x: str(x), OML_PATH.glob("**/*.yaml"))
+        )
+        self.run["code"].upload_files(source_files)
+
+        # log dataframe
+        self.run["dataset"].upload(str(Path(cfg["dataset_root"]) / cfg["dataframe_name"]))
+
+    def log_figure(self, fig: plt.Figure, title: str, idx: int) -> None:
+        from neptune.types import File  # this is the optional dependency
+
+        self.experiment[title].log(File.as_image(fig))
+
+
+class WandBPipelineLogger(WandbLogger, IPipelineLogger):
+    def log_experiment_info(self, cfg: TCfg) -> None:
+        # this is the optional dependency
+        import wandb
+
+        self.log_hyperparams(prepare_config_to_logging(cfg))
+
+        tags = prepare_tags(cfg)
+        self.experiment.tags = tags
+
+        # log transforms as files
+        keys_files = save_transforms_as_files(cfg)
+        if keys_files:
+            transforms = wandb.Artifact("transforms", type="transforms")
+            for _, transforms_file in keys_files:
+                transforms.add_file(transforms_file)
+            self.experiment.log_artifact(transforms)
+
+        # log source code
+        code = wandb.Artifact("source_code", type="code")
+        code.add_dir(OML_PATH, name="oml")
+        self.experiment.log_artifact(code)
+
+        # log dataset
+        dataset = wandb.Artifact("dataset", type="dataset")
+        dataset.add_file(str(Path(cfg["dataset_root"]) / cfg["dataframe_name"]))
+        self.experiment.log_artifact(dataset)
+
+    def log_figure(self, fig: plt.Figure, title: str, idx: int) -> None:
+        fig_img = figure_to_nparray(fig)
+        self.log_image(images=[fig_img], key=title)
+
+
+class TensorBoardPipelineLogger(TensorBoardLogger, IPipelineLogger):
+    def log_experiment_info(self, cfg: TCfg) -> None:
+        pass
+
+    def log_figure(self, fig: plt.Figure, title: str, idx: int) -> None:
+        fig_img = figure_to_nparray(fig)
+        self.experiment.add_image(title, np.transpose(fig_img, (2, 0, 1)), idx)

--- a/oml/lightning/pipelines/train.py
+++ b/oml/lightning/pipelines/train.py
@@ -72,7 +72,7 @@ def extractor_training_pipeline(cfg: TCfg) -> None:
     pprint(cfg)
 
     logger = parse_logger_from_config(cfg)
-    logger.log_experiment_info(cfg)
+    logger.log_pipeline_info(cfg)
 
     trainer_engine_params = parse_engine_params_from_config(cfg)
     is_ddp = check_is_config_for_ddp(trainer_engine_params)

--- a/oml/lightning/pipelines/train.py
+++ b/oml/lightning/pipelines/train.py
@@ -11,9 +11,9 @@ from oml.lightning.callbacks.metric import MetricValCallback, MetricValCallbackD
 from oml.lightning.modules.extractor import ExtractorModule, ExtractorModuleDDP
 from oml.lightning.pipelines.parser import (
     check_is_config_for_ddp,
-    initialize_logging,
     parse_ckpt_callback_from_config,
     parse_engine_params_from_config,
+    parse_logger_from_config,
     parse_sampler_from_config,
     parse_scheduler_from_config,
 )
@@ -70,7 +70,9 @@ def extractor_training_pipeline(cfg: TCfg) -> None:
 
     cfg = dictconfig_to_dict(cfg)
     pprint(cfg)
-    logger = initialize_logging(cfg)
+
+    logger = parse_logger_from_config(cfg)
+    logger.log_experiment_info(cfg)
 
     trainer_engine_params = parse_engine_params_from_config(cfg)
     is_ddp = check_is_config_for_ddp(trainer_engine_params)

--- a/oml/lightning/pipelines/train_postprocessor.py
+++ b/oml/lightning/pipelines/train_postprocessor.py
@@ -120,7 +120,7 @@ def postprocessor_training_pipeline(cfg: DictConfig) -> None:
     pprint(cfg)
 
     logger = parse_logger_from_config(cfg)
-    logger.log_experiment_info(cfg)
+    logger.log_pipeline_info(cfg)
 
     trainer_engine_params = parse_engine_params_from_config(cfg)
     is_ddp = check_is_config_for_ddp(trainer_engine_params)

--- a/oml/lightning/pipelines/train_postprocessor.py
+++ b/oml/lightning/pipelines/train_postprocessor.py
@@ -21,9 +21,9 @@ from oml.lightning.modules.pairwise_postprocessing import (
 )
 from oml.lightning.pipelines.parser import (
     check_is_config_for_ddp,
-    initialize_logging,
     parse_ckpt_callback_from_config,
     parse_engine_params_from_config,
+    parse_logger_from_config,
     parse_sampler_from_config,
     parse_scheduler_from_config,
 )
@@ -118,7 +118,9 @@ def postprocessor_training_pipeline(cfg: DictConfig) -> None:
 
     cfg = dictconfig_to_dict(cfg)
     pprint(cfg)
-    logger = initialize_logging(cfg)
+
+    logger = parse_logger_from_config(cfg)
+    logger.log_experiment_info(cfg)
 
     trainer_engine_params = parse_engine_params_from_config(cfg)
     is_ddp = check_is_config_for_ddp(trainer_engine_params)

--- a/oml/registry/loggers.py
+++ b/oml/registry/loggers.py
@@ -1,13 +1,20 @@
 import os
-from typing import Any, Dict, Union
-
-from pytorch_lightning.loggers import NeptuneLogger, TensorBoardLogger, WandbLogger
-from pytorch_lightning.loggers.logger import Logger
+from typing import Any, Dict
 
 from oml.const import TCfg
+from oml.interfaces.loggers import IPipelineLogger
+from oml.lightning.pipelines.logging import (
+    NeptunePipelineLogger,
+    TensorBoardPipelineLogger,
+    WandBPipelineLogger,
+)
 from oml.utils.misc import dictconfig_to_dict
 
-LOGGERS_REGISTRY = {"wandb": WandbLogger, "neptune": NeptuneLogger, "tensorboard": TensorBoardLogger}
+LOGGERS_REGISTRY = {
+    "wandb": WandBPipelineLogger,
+    "neptune": NeptunePipelineLogger,
+    "tensorboard": TensorBoardPipelineLogger,
+}
 
 CLOUD_TOKEN_NAMES = {"wandb": "WANDB_API_KEY", "neptune": "NEPTUNE_API_TOKEN"}
 TOKEN_ERROR_MESSAGE = (
@@ -17,15 +24,15 @@ TOKEN_ERROR_MESSAGE = (
 )
 
 
-def get_logger(name: str, **kwargs: Dict[str, Any]) -> Logger:
+def get_logger(name: str, **kwargs: Dict[str, Any]) -> IPipelineLogger:
     if (name in CLOUD_TOKEN_NAMES) and (CLOUD_TOKEN_NAMES[name] not in os.environ):
         token_name = CLOUD_TOKEN_NAMES[name]
         raise ValueError(TOKEN_ERROR_MESSAGE.format(name.upper(), token_name, token_name))
 
-    return LOGGERS_REGISTRY[name](**kwargs)
+    return LOGGERS_REGISTRY[name](**kwargs)  # type: ignore
 
 
-def get_logger_by_cfg(cfg: TCfg) -> Union[bool, Logger]:
+def get_logger_by_cfg(cfg: TCfg) -> IPipelineLogger:
     cfg = dictconfig_to_dict(cfg)
     logger = get_logger(cfg["name"], **cfg["args"])
     return logger

--- a/oml/utils/misc.py
+++ b/oml/utils/misc.py
@@ -7,7 +7,7 @@ import numpy as np
 import torch
 from omegaconf import DictConfig, OmegaConf
 
-from oml.const import DOTENV_PATH, TCfg
+from oml.const import TCfg
 
 
 def find_value_ids(it: Iterable[Any], value: Any) -> List[int]:
@@ -66,12 +66,6 @@ def flatten_dict(
         else:
             items.append((new_key, v))
     return dict(items)
-
-
-def load_dotenv() -> None:
-    import dotenv  # this is the optional dependency
-
-    dotenv.load_dotenv(DOTENV_PATH)
 
 
 def dictconfig_to_dict(cfg: TCfg) -> Dict[str, Any]:
@@ -181,7 +175,6 @@ __all__ = [
     "set_global_seed",
     "one_hot",
     "flatten_dict",
-    "load_dotenv",
     "dictconfig_to_dict",
     "smart_sample",
     "clip_max",

--- a/tests/test_oml/test_registry/test_registry.py
+++ b/tests/test_oml/test_registry/test_registry.py
@@ -2,13 +2,14 @@
 from pathlib import Path
 from typing import Any, Dict
 
+import dotenv
 import pytest
 import yaml
 from omegaconf import OmegaConf
 from torch import nn
 from torch.optim import Optimizer
 
-from oml.const import CONFIGS_PATH, TCfg
+from oml.const import CONFIGS_PATH, DOTENV_PATH, TCfg
 from oml.registry.loggers import LOGGERS_REGISTRY, get_logger
 from oml.registry.losses import LOSSES_REGISTRY, get_criterion
 from oml.registry.miners import MINERS_REGISTRY, get_miner
@@ -33,7 +34,7 @@ from oml.registry.transforms import (
     get_transforms_for_pretrained,
     save_transforms_as_files,
 )
-from oml.utils.misc import dictconfig_to_dict, load_dotenv
+from oml.utils.misc import dictconfig_to_dict
 
 
 def get_sampler_kwargs_runtime() -> Any:
@@ -64,7 +65,7 @@ def get_opt() -> Optimizer:
     ],
 )
 def test_registry(folder_name, registry, factory_fun, runtime_args) -> None:
-    load_dotenv()  # we need to load tokens for cloud loggers (Neptune, W & B)
+    dotenv.load_dotenv(DOTENV_PATH)  # we need to load tokens for cloud loggers (Neptune, W & B)
 
     for obj_name in registry.keys():
         cfg = dictconfig_to_dict(OmegaConf.load(CONFIGS_PATH / folder_name / f"{obj_name}.yaml"))

--- a/tests/test_runs/test_pipelines/configs/train_with_bboxes.yaml
+++ b/tests/test_runs/test_pipelines/configs/train_with_bboxes.yaml
@@ -17,7 +17,7 @@ transforms_train:
     im_size: 32
 
 transforms_val:
-  name: norm_resize_torch
+  name: norm_resize_albu
   args:
     im_size: 48
 
@@ -67,6 +67,11 @@ metric_args:
   visualize_only_overall_category: True
 
 log_images: True
+
+logger:
+  name: wandb
+  args:
+    project: "test_project"
 
 metric_for_checkpointing: OVERALL/cmc/5
 

--- a/tests/test_runs/test_pipelines/configs/train_with_categories.yaml
+++ b/tests/test_runs/test_pipelines/configs/train_with_categories.yaml
@@ -12,7 +12,7 @@ num_workers: 0
 cache_size: 0
 
 transforms_train:
-  name: augs_albu
+  name: augs_torch
   args:
     im_size: 64
 

--- a/tests/test_runs/test_pipelines/configs/train_with_sequence.yaml
+++ b/tests/test_runs/test_pipelines/configs/train_with_sequence.yaml
@@ -12,7 +12,7 @@ num_workers: 0
 cache_size: 10
 
 transforms_train:
-  name: augs_torch
+  name: augs_albu
   args:
     im_size: 64
 
@@ -76,9 +76,9 @@ max_epochs: 2
 valid_period: 1
 
 logger:
-  name: tensorboard
+  name: neptune
   args:
-    save_dir: "."
+    project: "oml-team/test"
 
 
 lightning_trainer_extra_args:

--- a/tests/test_runs/test_pipelines/test_pipelines.py
+++ b/tests/test_runs/test_pipelines/test_pipelines.py
@@ -1,18 +1,22 @@
+import os
 import shutil
 import subprocess
 import warnings
 from pathlib import Path
 from typing import List, Tuple
 
+import dotenv
 import pytest
 import torch
 import yaml  # type: ignore
 
-from oml.const import PROJECT_ROOT
+from oml.const import DOTENV_PATH, PROJECT_ROOT
 
 warnings.filterwarnings("ignore")
 
 SCRIPTS_PATH = PROJECT_ROOT / "tests/test_runs/test_pipelines/"
+
+dotenv.load_dotenv(DOTENV_PATH)  # we need to load tokens for cloud loggers (Neptune, W & B)
 
 
 def accelerator_devices_pairs() -> List[Tuple[str, int]]:
@@ -53,12 +57,16 @@ def test_train_and_validate(accelerator: str, devices: int) -> None:
 
 
 @pytest.mark.long
+@pytest.mark.needs_optional_dependency
+@pytest.mark.skipif(os.getenv("TEST_CLOUD_LOGGERS") != "yes", reason="To have more control.")
 @pytest.mark.parametrize("accelerator, devices", accelerator_devices_pairs())
 def test_train_with_bboxes(accelerator: str, devices: int) -> None:
     run("train_with_bboxes.py", accelerator, devices)
 
 
 @pytest.mark.long
+@pytest.mark.needs_optional_dependency
+@pytest.mark.skipif(os.getenv("TEST_CLOUD_LOGGERS") != "yes", reason="To have more control.")
 @pytest.mark.parametrize("accelerator, devices", accelerator_devices_pairs())
 def test_train_with_sequence(accelerator: str, devices: int) -> None:
     run("train_with_sequence.py", accelerator, devices)


### PR DESCRIPTION
* unified logging interfaces
* get rid of `if isinstance(...)` in `MetricsCallback`
* added cloud logging to tests (only to "all tests" on python 3.8)
* get rid of logging code in config parser 
* updated neptune version