### PR TITLE
Enable offline mode by default in ClearMLLogger class

### DIFF
--- a/oml/configs/logger/clearml.yaml
+++ b/oml/configs/logger/clearml.yaml
@@ -2,3 +2,4 @@ name: clearml
 args:
   project_name: "test_project"
   task_name: "test"
+  offline_mode: True

--- a/oml/lightning/pipelines/logging.py
+++ b/oml/lightning/pipelines/logging.py
@@ -49,7 +49,7 @@ class ClearMLLogger(Logger):
             k: v for k, v in kwargs.items() if k not in ("project_name", "task_name", "task_type", "offline_mode")
         }
 
-        if kwargs.get("offline_mode", False):
+        if kwargs.get("offline_mode", True):
             Task.set_offline(offline_mode=True)
             warnings.warn("ClearMLSaver: running in offline mode")
 


### PR DESCRIPTION
- Changed the default value of the `offline_mode` argument from False to True in ClearMLLogger class.
- Added `offline_mode: True` parameter to clearml.yaml configuration file for consistency and clarity.
