### PR TITLE
Rework retrieval metrics 2

### DIFF
--- a/oml/functional/metrics.py
+++ b/oml/functional/metrics.py
@@ -4,107 +4,94 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
-from torch import Tensor
+from torch import BoolTensor, LongTensor, Tensor, isin, stack, tensor
 
 from oml.utils.misc import check_if_nonempty_positive_integers, clip_max
-from oml.utils.misc_torch import PCA, pairwise_dist, take_2d
+from oml.utils.misc_torch import PCA, pairwise_dist
 
 TMetricsDict = Dict[str, Dict[Union[int, float], Union[float, Tensor]]]
 
 
 def calc_retrieval_metrics(
-    distances: Tensor,
-    mask_gt: Tensor,
-    mask_to_ignore: Optional[Tensor] = None,
+    retrieved_ids: LongTensor,
+    gt_ids: List[LongTensor],
     cmc_top_k: Tuple[int, ...] = (5,),
     precision_top_k: Tuple[int, ...] = (5,),
     map_top_k: Tuple[int, ...] = (5,),
-    fmr_vals: Tuple[int, ...] = (1,),
     reduce: bool = True,
 ) -> TMetricsDict:
     """
     Function to count different retrieval metrics.
 
     Args:
-        distances: Distance matrix with the shape of ``[query_size, gallery_size]``
-        mask_gt: ``(i,j)`` element indicates if for ``i``-th query ``j``-th gallery is the correct prediction
-        mask_to_ignore: Binary matrix to indicate that some elements in the gallery cannot be used
-                     as answers and must be ignored
+        retrieved_ids: Top N gallery ids retrieved for every query with the shape of ``[n_query, top_n]``.
+            Every element is within the range ``(0, n_gallery - 1)``.
+        gt_ids: Gallery ids relevant to every query, list of ``n_query`` elements where every element may
+            have an arbitrary length. Every element is within the range ``(0, n_gallery - 1)``
         cmc_top_k: Values of ``k`` to calculate ``cmc@k`` (`Cumulative Matching Characteristic`)
         precision_top_k: Values of ``k`` to calculate ``precision@k``
         map_top_k: Values of ``k`` to calculate ``map@k`` (`Mean Average Precision`)
-        fmr_vals: Values of ``fmr`` (measured in quantiles) to calculate ``fnmr@fmr`` (`False Non Match Rate
-                  at the given False Match Rate`).
-                  For example, if ``fmr_values`` is (0.2, 0.4) we will calculate ``fnmr@fmr=0.2`` and ``fnmr@fmr=0.4``
         reduce: If ``False`` return metrics for each query without averaging
 
     Returns:
         Metrics dictionary.
 
     """
-    top_k_args = [cmc_top_k, precision_top_k, map_top_k]
+    assert retrieved_ids.ndim == 2, "Retrieved ids must be a tensor with the shape of [n_query, top_n]."
+    assert len(retrieved_ids) == len(gt_ids), "Numbers of queries have be the same."
+    n_queries = len(retrieved_ids)
 
-    if not any(top_k_args + [fmr_vals]):
-        raise ValueError("You must specify arguments for at leas 1 metric to calculate it")
-
-    if distances.shape != mask_gt.shape:
-        raise ValueError(
-            f"Distances matrix has the shape of {distances.shape}, "
-            f"but mask_to_ignore has the shape of {mask_gt.shape}."
-        )
-
-    if (mask_to_ignore is not None) and (mask_to_ignore.shape != distances.shape):
-        raise ValueError(
-            f"Distances matrix has the shape of {distances.shape}, "
-            f"but mask_to_ignore has the shape of {mask_to_ignore.shape}."
-        )
-
-    query_sz, gallery_sz = distances.shape
-
-    for top_k_arg in top_k_args:
-        for k in top_k_arg:
-            if k > gallery_sz:
-                warnings.warn(
-                    f"Your desired k={k} more than gallery_size={gallery_sz}. "
-                    f"We'll calculate metrics with k limited by the gallery size."
-                )
-
-    if mask_to_ignore is not None:
-        distances, mask_gt = apply_mask_to_ignore(distances=distances, mask_gt=mask_gt, mask_to_ignore=mask_to_ignore)
-
-    cmc_top_k_clipped = clip_max(cmc_top_k, gallery_sz)
-    precision_top_k_clipped = clip_max(precision_top_k, gallery_sz)
-    map_top_k_clipped = clip_max(map_top_k, gallery_sz)
-
-    max_k = max([*cmc_top_k, *precision_top_k, *map_top_k])
-    max_k = min(max_k, gallery_sz)
-
-    _, ii_top_k = torch.topk(distances, k=max_k, largest=False)
-    gt_tops = take_2d(mask_gt, ii_top_k)
-    n_gt = mask_gt.sum(dim=1)
+    # let's mark every correctly retrieved item as True and vice versa
+    gt_tops = stack([isin(retrieved_ids[i], gt_ids[i]) for i in range(n_queries)]).bool()
+    n_gts = tensor([len(ids) for ids in gt_ids]).long()
 
     metrics: TMetricsDict = defaultdict(dict)
 
     if cmc_top_k:
-        cmc = calc_cmc(gt_tops, cmc_top_k_clipped)
+        cmc = calc_cmc(gt_tops, cmc_top_k)
         metrics["cmc"] = dict(zip(cmc_top_k, cmc))
 
     if precision_top_k:
-        precision = calc_precision(gt_tops, n_gt, precision_top_k_clipped)
+        precision = calc_precision(gt_tops, n_gts, precision_top_k)
         metrics["precision"] = dict(zip(precision_top_k, precision))
 
     if map_top_k:
-        map = calc_map(gt_tops, n_gt, map_top_k_clipped)
+        map = calc_map(gt_tops, n_gts, map_top_k)
         metrics["map"] = dict(zip(map_top_k, map))
-
-    if fmr_vals:
-        pos_dist, neg_dist = extract_pos_neg_dists(distances, mask_gt, mask_to_ignore)
-        fnmr_at_fmr = calc_fnmr_at_fmr(pos_dist, neg_dist, fmr_vals)
-        metrics["fnmr@fmr"] = dict(zip(fmr_vals, fnmr_at_fmr))
 
     if reduce:
         metrics = reduce_metrics(metrics)
 
+    return metrics
+
+
+def calc_retrieval_metrics_on_full(
+    distances: Tensor,
+    mask_gt: Tensor,
+    mask_to_ignore: Optional[Tensor] = None,
+    cmc_top_k: Tuple[int, ...] = (5,),
+    precision_top_k: Tuple[int, ...] = (5,),
+    map_top_k: Tuple[int, ...] = (5,),
+    reduce: bool = True,
+) -> TMetricsDict:
+    # todo 522: get rid of this tmp function
+    if mask_to_ignore is not None:
+        distances, mask_gt = apply_mask_to_ignore(distances=distances, mask_gt=mask_gt, mask_to_ignore=mask_to_ignore)
+
+    max_k_arg = max([*cmc_top_k, *precision_top_k, *map_top_k])
+    k = min(distances.shape[1], max_k_arg)
+    _, retrieved_ids = torch.topk(distances, largest=False, k=k)
+
+    gt_ids = [LongTensor(row.nonzero()).view(-1) for row in mask_gt]
+
+    metrics = calc_retrieval_metrics(
+        cmc_top_k=cmc_top_k,
+        precision_top_k=precision_top_k,
+        map_top_k=map_top_k,
+        reduce=reduce,
+        gt_ids=gt_ids,
+        retrieved_ids=retrieved_ids,
+    )
     return metrics
 
 
@@ -141,6 +128,22 @@ def reduce_metrics(metrics_to_reduce: TMetricsDict) -> TMetricsDict:
             output[k] = v
         else:
             output[k] = reduce_metrics(v)  # type: ignore
+
+    return output
+
+
+def take_unreduced_metrics_by_mask(metrics: TMetricsDict, mask: BoolTensor) -> TMetricsDict:
+    output: TMetricsDict = {}
+
+    for k, v in metrics.items():
+        if isinstance(v, Tensor) and v.numel() > 1:
+            output[k] = v[mask]
+        elif isinstance(v, np.ndarray) and v.size > 1:
+            output[k] = v[mask]
+        elif isinstance(v, (float, int)):
+            output[k] = v
+        else:
+            output[k] = take_unreduced_metrics_by_mask(v, mask)  # type: ignore
 
     return output
 
@@ -598,4 +601,5 @@ __all__ = [
     "calc_mask_to_ignore",
     "calc_distance_matrix",
     "reduce_metrics",
+    "take_unreduced_metrics_by_mask",
 ]

--- a/tests/test_oml/test_functional/test_metrics/test_cmc_metric_old.py
+++ b/tests/test_oml/test_functional/test_metrics/test_cmc_metric_old.py
@@ -6,7 +6,9 @@ import pytest
 import torch
 from torch import Tensor
 
-from oml.functional.metrics import calc_retrieval_metrics
+from oml.functional.metrics import (
+    calc_retrieval_metrics_on_full as calc_retrieval_metrics,
+)
 from oml.utils.misc_torch import pairwise_dist
 
 
@@ -18,7 +20,6 @@ def cmc_score_count(distances: Tensor, mask_gt: Tensor, topk: int, mask_to_ignor
         cmc_top_k=(topk,),
         map_top_k=tuple(),
         precision_top_k=tuple(),
-        fmr_vals=tuple(),
     )
     return metrics["cmc"][topk]
 

--- a/tests/test_oml/test_functional/test_metrics/test_retrieval_metrics.py
+++ b/tests/test_oml/test_functional/test_metrics/test_retrieval_metrics.py
@@ -14,7 +14,9 @@ from oml.functional.metrics import (
     calc_map,
     calc_mask_to_ignore,
     calc_precision,
-    calc_retrieval_metrics,
+)
+from oml.functional.metrics import (
+    calc_retrieval_metrics_on_full as calc_retrieval_metrics,
 )
 from oml.metrics.embeddings import validate_dataset
 from oml.utils.misc import remove_unused_kwargs

--- a/tests/test_oml/test_postprocessor/test_pairwise_embeddings.py
+++ b/tests/test_oml/test_postprocessor/test_pairwise_embeddings.py
@@ -7,7 +7,10 @@ import pytest
 import torch
 from torch import Tensor
 
-from oml.functional.metrics import calc_distance_matrix, calc_retrieval_metrics
+from oml.functional.metrics import calc_distance_matrix
+from oml.functional.metrics import (
+    calc_retrieval_metrics_on_full as calc_retrieval_metrics,
+)
 from oml.interfaces.models import IPairwiseModel
 from oml.models.meta.siamese import LinearTrivialDistanceSiamese
 from oml.retrieval.postprocessors.pairwise import PairwiseEmbeddingsPostprocessor
@@ -121,7 +124,7 @@ def test_trivial_processing_fixes_broken_perfect_case() -> None:
         top_k = (randint(1, ng - 1),)
         top_n = randint(2, 10)
 
-        args = {"mask_gt": mask_gt, "precision_top_k": top_k, "map_top_k": top_k, "cmc_top_k": top_k, "fmr_vals": ()}
+        args = {"mask_gt": mask_gt, "precision_top_k": top_k, "map_top_k": top_k, "cmc_top_k": top_k}
 
         # Metrics before
         metrics = flatten_dict(calc_retrieval_metrics(distances=distances, **args))
@@ -207,7 +210,6 @@ def test_processing_not_changing_non_sensitive_metrics(top_n: int) -> None:
     args = {
         "cmc_top_k": (top_n,),
         "precision_top_k": (top_n,),
-        "fmr_vals": tuple(),
         "map_top_k": tuple(),
         "mask_gt": mask_gt,
     }


### PR DESCRIPTION
this PR is the simplified version of this draft: https://github.com/OML-Team/open-metric-learning/pull/545 , so, don't really need the second review here 

Changelog:
- Separated map, precision, cmc and fnmr and pfc metrics (there is no more single function that computes all of them)
- Changed signature of the `calc_retrieval_metrics` (it works with the top k closest items instead of the full gallery)
- Removed repeated calculations in EmbeddingMetrics when slicing over categories 
