### PR TITLE
Update _read_bytes function in images.py support for URL

### DIFF
--- a/oml/datasets/images.py
+++ b/oml/datasets/images.py
@@ -157,8 +157,17 @@ class ImageBaseDataset(IBaseDataset, IVisualizableDataset):
 
     @staticmethod
     def _read_bytes(path: Union[Path, str]) -> bytes:
-        with open(str(path), "rb") as fin:
-            return fin.read()
+        if isinstance(path, str) and path.startswith(('http://', 'https://')):
+            # If the path is a URL, use requests to fetch the content
+            response = requests.get(path)
+            if response.status_code == 200:
+                return response.content
+            else:
+                raise ValueError(f"Failed to fetch image from URL: {path}")
+        else:
+            # Otherwise, assume it's a local file path
+            with open(str(path), "rb") as fin:
+                return fin.read()
 
     def __getitem__(self, item: int) -> Dict[str, Union[FloatTensor, int]]:
         img_bytes = self.read_bytes(self._paths[item])


### PR DESCRIPTION
Add support for fetching images from URLs in _read_bytes_image

Previously, the function only supported reading image files from local paths. This commit extends its functionality to also fetch images from URLs if the path starts with 'http://' or 'https://'. The function now uses the 'requests' library to download the image content when a URL is provided.

If the URL fetch is successful, the image content is returned as bytes. If the status code is not 200, a ValueError is raised with a message indicating the failure.

The existing file reading functionality remains unchanged for non-URL paths, ensuring backward compatibility.

Changes:
- Modified _read_bytes_image to check if the path is a URL
- Added conditional logic to handle URL paths using requests.get
- Included error handling for failed URL fetch attempts

For now, we don't push you to follow any predefined schema of issue, but ensure you've already read our contribution guide: https://open-metric-learning.readthedocs.io/en/latest/from_readme/contributing.html.
