### PR TITLE
Misc small changes for OML 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,22 +344,21 @@ from oml.retrieval import RetrievalResults
 from oml.utils.download_mock_dataset import download_mock_dataset
 from oml.registry.transforms import get_transforms_for_pretrained
 
-extractor = ViTExtractor.from_pretrained("vits16_dino")
+extractor = ViTExtractor.from_pretrained("vits16_dino").to("cpu")
 transform, _ = get_transforms_for_pretrained("vits16_dino")
 
 _, df_val = download_mock_dataset(global_paths=True, df_name="df_with_category.csv")
 dataset = ImageQueryGalleryLabeledDataset(df_val, transform=transform)
+embeddings = inference(extractor, dataset, batch_size=4, num_workers=0)
+
+rr = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_retrieve=5)
+rr.visualize(query_ids=[2, 1], dataset=dataset, show=True)
 
 # you can optionally provide categories to have category wise metrics
 query_categories = np.array(dataset.extra_data["category"])[dataset.get_query_ids()]
-
-embeddings = inference(extractor, dataset, batch_size=4)
-
-rr = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_retrieve=5)
 metrics = calc_retrieval_metrics_rr(rr, query_categories, map_top_k=(3, 5), precision_top_k=(5,), cmc_top_k=(3,))
-
 print(rr, "\n", metrics)
-rr.visualize(query_ids=[2, 1], dataset=dataset, show=True)
+
 ```
 [comment]:vanilla-validation-end
 </p>
@@ -455,17 +454,16 @@ from oml.retrieval.retrieval_results import RetrievalResults
 _, df_test = download_mock_dataset(global_paths=True)
 del df_test["label"]  # we don't need gt labels for doing predictions
 
-extractor = ViTExtractor.from_pretrained("vits16_dino")
+extractor = ViTExtractor.from_pretrained("vits16_dino").to("cpu")
 transform, _ = get_transforms_for_pretrained("vits16_dino")
 
 dataset = ImageQueryGalleryDataset(df_test, transform=transform)
 embeddings = inference(extractor, dataset, batch_size=4, num_workers=0)
 
-retrieval_results = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_retrieve=5)
+rr = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_retrieve=5)
+rr.visualize(query_ids=[0, 1], dataset=dataset, show=True)
 
-retrieval_results.visualize(query_ids=[0, 1], dataset=dataset, show=True)
-
-print(retrieval_results)  # you get the ids of retrieved items and the corresponding distances
+print(rr)  # you get the ids of retrieved items and the corresponding distances
 
 ```
 [comment]:usage-retrieval-end
@@ -539,7 +537,7 @@ from oml.const import CKPT_SAVE_ROOT as CKPT_DIR, MOCK_DATASET_PATH as DATA_DIR
 from oml.models import ViTExtractor
 from oml.registry.transforms import get_transforms_for_pretrained
 
-model = ViTExtractor.from_pretrained("vits16_dino")
+model = ViTExtractor.from_pretrained("vits16_dino").to("cpu").eval()
 transforms, im_reader = get_transforms_for_pretrained("vits16_dino")
 
 img = im_reader(DATA_DIR / "images" / "circle_1.jpg")  # put path to your image here

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ rr = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_re
 metrics = calc_retrieval_metrics_rr(rr, query_categories, map_top_k=(3, 5), precision_top_k=(5,), cmc_top_k=(3,))
 
 print(rr, "\n", metrics)
-rr.visualize(query_ids=[2, 1], dataset=dataset)
+rr.visualize(query_ids=[2, 1], dataset=dataset, show=True)
 ```
 [comment]:vanilla-validation-end
 </p>
@@ -463,7 +463,7 @@ embeddings = inference(extractor, dataset, batch_size=4, num_workers=0)
 
 retrieval_results = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_retrieve=5)
 
-retrieval_results.visualize(query_ids=[0, 1], dataset=dataset).show()
+retrieval_results.visualize(query_ids=[0, 1], dataset=dataset, show=True)
 
 print(retrieval_results)  # you get the ids of retrieved items and the corresponding distances
 

--- a/docs/readme/examples_source/extractor/retrieval_usage.md
+++ b/docs/readme/examples_source/extractor/retrieval_usage.md
@@ -15,17 +15,16 @@ from oml.retrieval.retrieval_results import RetrievalResults
 _, df_test = download_mock_dataset(global_paths=True)
 del df_test["label"]  # we don't need gt labels for doing predictions
 
-extractor = ViTExtractor.from_pretrained("vits16_dino")
+extractor = ViTExtractor.from_pretrained("vits16_dino").to("cpu")
 transform, _ = get_transforms_for_pretrained("vits16_dino")
 
 dataset = ImageQueryGalleryDataset(df_test, transform=transform)
 embeddings = inference(extractor, dataset, batch_size=4, num_workers=0)
 
-retrieval_results = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_retrieve=5)
+rr = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_retrieve=5)
+rr.visualize(query_ids=[0, 1], dataset=dataset, show=True)
 
-retrieval_results.visualize(query_ids=[0, 1], dataset=dataset, show=True)
-
-print(retrieval_results)  # you get the ids of retrieved items and the corresponding distances
+print(rr)  # you get the ids of retrieved items and the corresponding distances
 
 ```
 [comment]:usage-retrieval-end

--- a/docs/readme/examples_source/extractor/retrieval_usage.md
+++ b/docs/readme/examples_source/extractor/retrieval_usage.md
@@ -23,7 +23,7 @@ embeddings = inference(extractor, dataset, batch_size=4, num_workers=0)
 
 retrieval_results = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_retrieve=5)
 
-retrieval_results.visualize(query_ids=[0, 1], dataset=dataset).show()
+retrieval_results.visualize(query_ids=[0, 1], dataset=dataset, show=True)
 
 print(retrieval_results)  # you get the ids of retrieved items and the corresponding distances
 

--- a/docs/readme/examples_source/extractor/val.md
+++ b/docs/readme/examples_source/extractor/val.md
@@ -30,7 +30,7 @@ rr = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_re
 metrics = calc_retrieval_metrics_rr(rr, query_categories, map_top_k=(3, 5), precision_top_k=(5,), cmc_top_k=(3,))
 
 print(rr, "\n", metrics)
-rr.visualize(query_ids=[2, 1], dataset=dataset)
+rr.visualize(query_ids=[2, 1], dataset=dataset, show=True)
 ```
 [comment]:vanilla-validation-end
 </p>

--- a/docs/readme/examples_source/extractor/val.md
+++ b/docs/readme/examples_source/extractor/val.md
@@ -15,22 +15,21 @@ from oml.retrieval import RetrievalResults
 from oml.utils.download_mock_dataset import download_mock_dataset
 from oml.registry.transforms import get_transforms_for_pretrained
 
-extractor = ViTExtractor.from_pretrained("vits16_dino")
+extractor = ViTExtractor.from_pretrained("vits16_dino").to("cpu")
 transform, _ = get_transforms_for_pretrained("vits16_dino")
 
 _, df_val = download_mock_dataset(global_paths=True, df_name="df_with_category.csv")
 dataset = ImageQueryGalleryLabeledDataset(df_val, transform=transform)
+embeddings = inference(extractor, dataset, batch_size=4, num_workers=0)
+
+rr = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_retrieve=5)
+rr.visualize(query_ids=[2, 1], dataset=dataset, show=True)
 
 # you can optionally provide categories to have category wise metrics
 query_categories = np.array(dataset.extra_data["category"])[dataset.get_query_ids()]
-
-embeddings = inference(extractor, dataset, batch_size=4)
-
-rr = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_retrieve=5)
 metrics = calc_retrieval_metrics_rr(rr, query_categories, map_top_k=(3, 5), precision_top_k=(5,), cmc_top_k=(3,))
-
 print(rr, "\n", metrics)
-rr.visualize(query_ids=[2, 1], dataset=dataset, show=True)
+
 ```
 [comment]:vanilla-validation-end
 </p>

--- a/docs/readme/examples_source/extractor/val_with_sequence.md
+++ b/docs/readme/examples_source/extractor/val_with_sequence.md
@@ -53,7 +53,7 @@ rr = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_re
 metrics = calc_retrieval_metrics_rr(rr, map_top_k=(3, 5), precision_top_k=(5,), cmc_top_k=(3,))
 
 print(rr, "\n", metrics)
-rr.visualize(query_ids=[2, 1], dataset=dataset).show()
+rr.visualize(query_ids=[2, 1], dataset=dataset, show=True)
 
 ```
 [comment]:val-with-sequence-end

--- a/docs/readme/examples_source/extractor/val_with_sequence.md
+++ b/docs/readme/examples_source/extractor/val_with_sequence.md
@@ -42,18 +42,17 @@ from oml.retrieval import RetrievalResults
 from oml.utils.download_mock_dataset import download_mock_dataset
 from oml.metrics import calc_retrieval_metrics_rr
 
-extractor = ViTExtractor("vits16_dino", arch="vits16", normalise_features=False).eval()
+extractor = ViTExtractor("vits16_dino", arch="vits16", normalise_features=False).to("cpu")
 
 _, df_val = download_mock_dataset(global_paths=True, df_name="df_with_sequence.csv")  # <- sequence info is in the file
 dataset = ImageQueryGalleryLabeledDataset(df_val)
-
-embeddings = inference(extractor, dataset, batch_size=4)
+embeddings = inference(extractor, dataset, batch_size=4, num_workers=0)
 
 rr = RetrievalResults.compute_from_embeddings(embeddings, dataset, n_items_to_retrieve=5)
-metrics = calc_retrieval_metrics_rr(rr, map_top_k=(3, 5), precision_top_k=(5,), cmc_top_k=(3,))
-
-print(rr, "\n", metrics)
 rr.visualize(query_ids=[2, 1], dataset=dataset, show=True)
+
+metrics = calc_retrieval_metrics_rr(rr, map_top_k=(3, 5), precision_top_k=(5,), cmc_top_k=(3,))
+print(rr, "\n", metrics)
 
 ```
 [comment]:val-with-sequence-end

--- a/docs/readme/examples_source/postprocessing/predict.md
+++ b/docs/readme/examples_source/postprocessing/predict.md
@@ -16,7 +16,7 @@ from oml.retrieval import RetrievalResults
 _, df_test = download_mock_dataset(global_paths=True)
 del df_test["label"]  # we don't need gt labels for doing predictions
 
-extractor = ViTExtractor.from_pretrained("vits16_dino")
+extractor = ViTExtractor.from_pretrained("vits16_dino").to("cpu")
 transforms, _ = get_transforms_for_pretrained("vits16_dino")
 
 dataset = ImageQueryGalleryDataset(df_test, transform=transforms)
@@ -32,6 +32,7 @@ rr_upd = postprocessor.process(rr, dataset=dataset)
 
 # You may see the first 3 positions have changed, but the rest remain the same:
 print(rr, "\n", rr_upd)
+
 ```
 [comment]:postprocessor-pred-end
 </p>

--- a/docs/readme/examples_source/zoo/models_usage.md
+++ b/docs/readme/examples_source/zoo/models_usage.md
@@ -4,7 +4,7 @@ from oml.const import CKPT_SAVE_ROOT as CKPT_DIR, MOCK_DATASET_PATH as DATA_DIR
 from oml.models import ViTExtractor
 from oml.registry.transforms import get_transforms_for_pretrained
 
-model = ViTExtractor.from_pretrained("vits16_dino")
+model = ViTExtractor.from_pretrained("vits16_dino").to("cpu").eval()
 transforms, im_reader = get_transforms_for_pretrained("vits16_dino")
 
 img = im_reader(DATA_DIR / "images" / "circle_1.jpg")  # put path to your image here

--- a/oml/datasets/images.py
+++ b/oml/datasets/images.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import albumentations as albu
 import numpy as np
 import pandas as pd
-import torch
 import torchvision
 from torch import BoolTensor, FloatTensor, LongTensor
 
@@ -38,7 +37,7 @@ from oml.interfaces.datasets import (
 from oml.registry.transforms import get_transforms
 from oml.transforms.images.utils import TTransforms, get_im_reader_for_transforms
 from oml.utils.dataframe_format import check_retrieval_dataframe_format
-from oml.utils.images.images import TImReader, get_img_with_bbox
+from oml.utils.images.images import TImReader, draw_bbox, imread_pillow
 
 
 def parse_bboxes(df: pd.DataFrame) -> Optional[TBBoxes]:
@@ -162,8 +161,9 @@ class ImageBaseDataset(IBaseDataset, IVisualizableDataset):
         return len(self._paths)
 
     def visualize(self, item: int, color: TColor = BLACK) -> np.ndarray:
-        bbox = torch.tensor(self._bboxes[item]) if (self._bboxes is not None) else torch.tensor([torch.nan] * 4)
-        image = get_img_with_bbox(im_path=self._paths[item], bbox=bbox, color=color)
+        img = np.array(imread_pillow(self.read_bytes(self._paths[item])))
+        bbox = self._bboxes[item] if (self._bboxes is not None) else None
+        image = draw_bbox(im=img, bbox=bbox, color=color)
 
         return image
 

--- a/oml/lightning/pipelines/parser.py
+++ b/oml/lightning/pipelines/parser.py
@@ -97,7 +97,7 @@ def parse_ckpt_callback_from_config(cfg: TCfg) -> ModelCheckpoint:
     return ModelCheckpoint(
         dirpath=Path.cwd() / "checkpoints",
         monitor=cfg["metric_for_checkpointing"],
-        mode="max",
+        mode=cfg.get("mode_for_checkpointing", "max"),
         save_top_k=1,
         verbose=True,
         filename="best",

--- a/oml/lightning/pipelines/train.py
+++ b/oml/lightning/pipelines/train.py
@@ -7,6 +7,7 @@ from torch.utils.data import DataLoader
 
 from oml.const import TCfg
 from oml.datasets.images import get_retrieval_images_datasets
+from oml.interfaces.datasets import ILabeledDataset, IQueryGalleryLabeledDataset
 from oml.lightning.callbacks.metric import MetricValCallback
 from oml.lightning.modules.extractor import ExtractorModule, ExtractorModuleDDP
 from oml.lightning.pipelines.parser import (
@@ -25,7 +26,7 @@ from oml.registry.transforms import get_transforms_by_cfg
 from oml.utils.misc import dictconfig_to_dict, set_global_seed
 
 
-def get_retrieval_loaders(cfg: TCfg) -> Tuple[DataLoader, DataLoader]:
+def get_retrieval_loaders(cfg: TCfg) -> Tuple[DataLoader, DataLoader, ILabeledDataset, IQueryGalleryLabeledDataset]:
     train_dataset, valid_dataset = get_retrieval_images_datasets(
         dataset_root=Path(cfg["dataset_root"]),
         transforms_train=get_transforms_by_cfg(cfg["transforms_train"]),
@@ -54,7 +55,7 @@ def get_retrieval_loaders(cfg: TCfg) -> Tuple[DataLoader, DataLoader]:
 
     loader_val = DataLoader(dataset=valid_dataset, batch_size=cfg["bs_val"], num_workers=cfg["num_workers"])
 
-    return loader_train, loader_val
+    return loader_train, loader_val, train_dataset, valid_dataset
 
 
 def extractor_training_pipeline(cfg: TCfg) -> None:
@@ -77,9 +78,10 @@ def extractor_training_pipeline(cfg: TCfg) -> None:
     trainer_engine_params = parse_engine_params_from_config(cfg)
     is_ddp = check_is_config_for_ddp(trainer_engine_params)
 
-    loader_train, loaders_val = get_retrieval_loaders(cfg)
+    loader_train, loaders_val, dataset_train, dataset_val = get_retrieval_loaders(cfg)
+    label2category = dataset_train.get_label2category()
     extractor = get_extractor_by_cfg(cfg["extractor"])
-    criterion = get_criterion_by_cfg(cfg["criterion"], **{"label2category": loader_train.dataset.get_label2category()})
+    criterion = get_criterion_by_cfg(cfg["criterion"], **{"label2category": label2category})  # type: ignore
     optimizable_parameters = [
         {"lr": cfg["optimizer"]["args"]["lr"], "params": extractor.parameters()},
         {"lr": cfg["optimizer"]["args"]["lr"], "params": criterion.parameters()},
@@ -98,18 +100,14 @@ def extractor_training_pipeline(cfg: TCfg) -> None:
         extractor=extractor,
         criterion=criterion,
         optimizer=optimizer,
-        input_tensors_key=loader_train.dataset.input_tensors_key,
-        labels_key=loader_train.dataset.labels_key,
+        input_tensors_key=dataset_train.input_tensors_key,
+        labels_key=dataset_train.labels_key,
         freeze_n_epochs=cfg.get("freeze_n_epochs", 0),
         **module_kwargs,
     )
 
-    metrics_calc = EmbeddingMetrics(
-        dataset=loaders_val.dataset,
-        **cfg.get("metric_args", {}),
-    )
-
-    metrics_clb = MetricValCallback(metric=metrics_calc, log_images=cfg.get("log_images", False))
+    metric = EmbeddingMetrics(dataset=dataset_val, **cfg.get("metric_args", {}))
+    metrics_clb = MetricValCallback(metric=metric, log_images=cfg.get("log_images", False))
 
     trainer = pl.Trainer(
         max_epochs=cfg["max_epochs"],

--- a/oml/retrieval/retrieval_results.py
+++ b/oml/retrieval/retrieval_results.py
@@ -130,6 +130,7 @@ class RetrievalResults:
         n_galleries_to_show: int = 5,
         n_gt_to_show: int = N_GT_SHOW_EMBEDDING_METRICS,
         verbose: bool = False,
+        show: bool = False,
     ) -> plt.Figure:
         """
         Args:
@@ -138,6 +139,7 @@ class RetrievalResults:
             n_galleries_to_show: Number of closest gallery items to show.
             n_gt_to_show: Number of ground truth gallery items to show for reference (if available).
             verbose: Set ``True`` to allow prints.
+            show: Set ``True`` to instantly visualise the resulted figure.
 
         """
         dataset_name = dataset.__class__.__name__
@@ -203,6 +205,10 @@ class RetrievalResults:
                     plt.axis("off")
 
         fig.tight_layout()
+
+        if show:
+            fig.show()
+
         return fig
 
 

--- a/oml/utils/images/images.py
+++ b/oml/utils/images/images.py
@@ -19,7 +19,7 @@ import torch
 from PIL import Image
 from PIL.Image import Image as TPILImage
 
-from oml.const import PAD_COLOR, TColor
+from oml.const import PAD_COLOR, TBBox, TColor
 
 TImage = Union[PIL.Image.Image, np.ndarray]
 TImReader = Callable[[Union[Path, str, bytes]], TImage]
@@ -60,43 +60,28 @@ def imread_pillow(im_src: Union[Path, str, bytes]) -> TPILImage:
     return image.convert("RGB")
 
 
-def draw_bbox(im: np.ndarray, bbox: torch.Tensor, color: TColor) -> np.ndarray:
+def draw_bbox(im: np.ndarray, bbox: Optional[TBBox], color: TColor) -> np.ndarray:
     """
     Draws a single bounding box on the image.
     If the elements of the bbox are NaNs, we will draw bbox around the whole image.
 
     Args:
         im: Image
-        bbox: Single bounding in the format of [x1, y1, x2, y2]
+        bbox: Optional single bounding box in the format of ``[x1, y1, x2, y2]``.
         color: Tuple of 3 ints
     """
     im_ret = im.copy()
-    if not any(torch.isnan(bbox)):
-        x1, y1, x2, y2 = list(map(int, bbox))
-    elif all(torch.isnan(bbox)):
+
+    if bbox is None:
         x1, y1, x2, y2 = 0, 0, im_ret.shape[1], im_ret.shape[0]
     else:
-        raise ValueError("BBox can only consist of all NaNs or all numbers.")
+        x1, y1, x2, y2 = bbox
 
     im_avg_sz = (im_ret.shape[0] + im_ret.shape[1]) / 2
     thickness = max(3, int(0.05 * im_avg_sz))
     im_ret = cv2.rectangle(im_ret, (x1, y1), (x2, y2), thickness=thickness, color=color)
 
     return im_ret
-
-
-def get_img_with_bbox(im_path: str, bbox: torch.Tensor, color: TColor) -> np.ndarray:
-    """
-    Reads the image by its name and draws bbox on it.
-
-    Args:
-        im_path: Image path
-        bbox: Single bounding box in the format of [x1, y1, x2, y2]. It may also be a list of 4 torch("nan").
-        color: Tuple of 3 ints from 0 to 255
-    """
-    img = imread_cv2(im_path)
-    img = draw_bbox(img, bbox, color)
-    return img
 
 
 def square_pad(img: np.ndarray) -> np.ndarray:
@@ -138,7 +123,6 @@ __all__ = [
     "imread_cv2",
     "imread_pillow",
     "draw_bbox",
-    "get_img_with_bbox",
     "square_pad",
     "figure_to_nparray",
 ]

--- a/pipelines/features_extraction/configs_experimental/train_inshop_arcface.yaml
+++ b/pipelines/features_extraction/configs_experimental/train_inshop_arcface.yaml
@@ -45,6 +45,7 @@ metric_args:
 log_images: True
 
 metric_for_checkpointing: OVERALL/cmc/1
+mode_for_checkpointing: max
 
 extractor:
   name: vit_clip

--- a/pipelines/features_extraction/configs_experimental/train_inshop_with_mlp.yaml
+++ b/pipelines/features_extraction/configs_experimental/train_inshop_with_mlp.yaml
@@ -50,6 +50,7 @@ metric_args:
 log_images: True
 
 metric_for_checkpointing: OVERALL/cmc/1
+mode_for_checkpointing: max
 
 freeze_n_epochs: 5
 

--- a/pipelines/features_extraction/extractor_cars/train_cars.yaml
+++ b/pipelines/features_extraction/extractor_cars/train_cars.yaml
@@ -51,7 +51,7 @@ metric_args:
 # it can be replaced by the name of the exact category (but it's not the case for CARS dataset containing no categories).
 # you can check other metrics in your logger.
 metric_for_checkpointing: OVERALL/cmc/1
-
+mode_for_checkpointing: max  # set min for metrics like fnmr@fmr, max by default
 
 # extractor to train
 extractor:

--- a/pipelines/features_extraction/extractor_cub/train_cub.yaml
+++ b/pipelines/features_extraction/extractor_cub/train_cub.yaml
@@ -46,6 +46,7 @@ metric_args:
 log_images: False
 
 metric_for_checkpointing: OVERALL/cmc/1
+mode_for_checkpointing: max
 
 extractor:
   name: vit

--- a/pipelines/features_extraction/extractor_inshop/train_inshop.yaml
+++ b/pipelines/features_extraction/extractor_inshop/train_inshop.yaml
@@ -50,6 +50,7 @@ metric_args:
 log_images: True
 
 metric_for_checkpointing: OVERALL/cmc/1
+mode_for_checkpointing: max
 
 extractor:
   name: vit

--- a/pipelines/features_extraction/extractor_sop/train_sop.yaml
+++ b/pipelines/features_extraction/extractor_sop/train_sop.yaml
@@ -50,6 +50,7 @@ metric_args:
 log_images: False
 
 metric_for_checkpointing: OVERALL/cmc/1
+mode_for_checkpointing: max
 
 extractor:
   name: vit

--- a/pipelines/postprocessing/pairwise_postprocessing/extractor_train.yaml
+++ b/pipelines/postprocessing/pairwise_postprocessing/extractor_train.yaml
@@ -47,6 +47,7 @@ metric_args:
 log_images: False
 
 metric_for_checkpointing: OVERALL/cmc/1
+mode_for_checkpointing: max
 
 extractor:
   name: vit

--- a/pipelines/postprocessing/pairwise_postprocessing/postprocessor_train.yaml
+++ b/pipelines/postprocessing/pairwise_postprocessing/postprocessor_train.yaml
@@ -94,6 +94,8 @@ postprocessor:
     use_fp16: True
 
 metric_for_checkpointing: OVERALL/cmc/1
+mode_for_checkpointing: max
+
 log_images: False
 metric_args:
   metrics_to_exclude_from_visualization: [cmc,]

--- a/tests/test_runs/test_pipelines/configs/train_arcface_with_categories.yaml
+++ b/tests/test_runs/test_pipelines/configs/train_arcface_with_categories.yaml
@@ -48,12 +48,14 @@ bs_val: 2
 
 metric_args:
   cmc_top_k: [1, 5]
+  fmr_vals: [0.1, 0.3]
   return_only_overall_category: True
   visualize_only_overall_category: True
 
 log_images: True
 
-metric_for_checkpointing: OVERALL/cmc/1
+metric_for_checkpointing: OVERALL/fnmr@fmr/0.1
+mode_for_checkpointing: min
 
 max_epochs: 2
 valid_period: 1

--- a/tests/test_runs/test_pipelines/configs/train_postprocessor.yaml
+++ b/tests/test_runs/test_pipelines/configs/train_postprocessor.yaml
@@ -88,6 +88,8 @@ postprocessor:
     use_fp16: True
 
 metric_for_checkpointing: OVERALL/cmc/1
+mode_for_checkpointing: max
+
 log_images: False
 metric_args:
   cmc_top_k: [1, 5]

--- a/tests/test_runs/test_pipelines/configs/train_with_bboxes.yaml
+++ b/tests/test_runs/test_pipelines/configs/train_with_bboxes.yaml
@@ -74,6 +74,7 @@ logger:
     project: "test_project"
 
 metric_for_checkpointing: OVERALL/cmc/5
+mode_for_checkpointing: max
 
 max_epochs: 2
 valid_period: 2

--- a/tests/test_runs/test_pipelines/configs/train_with_categories.yaml
+++ b/tests/test_runs/test_pipelines/configs/train_with_categories.yaml
@@ -61,6 +61,7 @@ logger:
     tracking_uri: "file:./ml-runs"
 
 metric_for_checkpointing: OVERALL/cmc/1
+mode_for_checkpointing: max
 
 max_epochs: 2
 valid_period: 1

--- a/tests/test_runs/test_pipelines/configs/train_with_sequence.yaml
+++ b/tests/test_runs/test_pipelines/configs/train_with_sequence.yaml
@@ -71,6 +71,7 @@ metric_args:
 log_images: True
 
 metric_for_checkpointing: OVERALL/precision/5
+mode_for_checkpointing: max
 
 max_epochs: 2
 valid_period: 1

--- a/tests/test_runs/test_pipelines/test_pipelines.py
+++ b/tests/test_runs/test_pipelines/test_pipelines.py
@@ -58,7 +58,7 @@ def test_train_and_validate(accelerator: str, devices: int) -> None:
 
 @pytest.mark.long
 @pytest.mark.needs_optional_dependency
-@pytest.mark.skipif(os.getenv("TEST_CLOUD_LOGGERS") != "yes", reason="To have more control.")
+@pytest.mark.skipif(os.getenv("TEST_CLOUD_LOGGERS") != "yes", reason="env DOWNLOAD_ZOO_IN_TESTS != yes.")
 @pytest.mark.parametrize("accelerator, devices", accelerator_devices_pairs())
 def test_train_with_bboxes(accelerator: str, devices: int) -> None:
     run("train_with_bboxes.py", accelerator, devices)
@@ -66,7 +66,7 @@ def test_train_with_bboxes(accelerator: str, devices: int) -> None:
 
 @pytest.mark.long
 @pytest.mark.needs_optional_dependency
-@pytest.mark.skipif(os.getenv("TEST_CLOUD_LOGGERS") != "yes", reason="To have more control.")
+@pytest.mark.skipif(os.getenv("TEST_CLOUD_LOGGERS") != "yes", reason="env DOWNLOAD_ZOO_IN_TESTS != yes.")
 @pytest.mark.parametrize("accelerator, devices", accelerator_devices_pairs())
 def test_train_with_sequence(accelerator: str, devices: int) -> None:
     run("train_with_sequence.py", accelerator, devices)


### PR DESCRIPTION
**CHANGLELOG**

* Simplified handling nans in bboxes
* Improved typings in training pipelines 
* Added show argument to `RetrievalResults.visualise()`
* Specified reason for skipping cloud logging tests
* Polished md examples
* Added `mode_for_checkpointing` to Pipeline config