### PR TITLE
Pass using_checkpoint flag from ViTUnicomExtractor to VisionTransformer

### DIFF
--- a/oml/models/vit_unicom/external/vision_transformer.py
+++ b/oml/models/vit_unicom/external/vision_transformer.py
@@ -279,7 +279,7 @@ class PatchEmbedding(nn.Module):
         return x
 
 
-def build_model(name="ViT-L/14@336px"):
+def build_model(name="ViT-L/14@336px", using_checkpoint: bool = True):
     if name == "ViT-B/32":
         model = VisionTransformer(
             input_size=224,
@@ -290,7 +290,7 @@ def build_model(name="ViT-L/14@336px"):
             depth=12,
             num_heads=12,
             drop_path_rate=0.1,
-            using_checkpoint=True,
+            using_checkpoint=using_checkpoint,
         )
     elif name == "ViT-B/16":
         model = VisionTransformer(
@@ -302,7 +302,7 @@ def build_model(name="ViT-L/14@336px"):
             depth=12,
             num_heads=12,
             drop_path_rate=0.1,
-            using_checkpoint=True,
+            using_checkpoint=using_checkpoint,
         )
     elif name == "ViT-L/14":
         model = VisionTransformer(
@@ -314,7 +314,7 @@ def build_model(name="ViT-L/14@336px"):
             depth=24,
             num_heads=16,
             drop_path_rate=0.1,
-            using_checkpoint=True,
+            using_checkpoint=using_checkpoint,
         )
     elif name == "ViT-L/14@336px":
         model = VisionTransformer(
@@ -326,7 +326,7 @@ def build_model(name="ViT-L/14@336px"):
             depth=24,
             num_heads=16,
             drop_path_rate=0.1,
-            using_checkpoint=True,
+            using_checkpoint=using_checkpoint,
         )
     return model
 

--- a/oml/models/vit_unicom/extractor.py
+++ b/oml/models/vit_unicom/extractor.py
@@ -58,19 +58,25 @@ class ViTUnicomExtractor(IExtractor):
     }
 
     def __init__(
-        self,
-        weights: Optional[Union[Path, str]],
-        arch: str,
-        normalise_features: bool,
-        using_checkpoint: bool = True
+        self, weights: Optional[Union[Path, str]], arch: str, normalise_features: bool, use_gradiend_ckpt: bool = True
     ):
+        """
+        Args:
+            weights: Path to weights or a special key to download pretrained checkpoint, use ``None`` to
+             randomly initialize model's weights. You can check the available pretrained checkpoints
+             in ``self.pretrained_models``.
+            arch: Might be one of ``vitb32_unicom``, ``vitb16_unicom``, ``vitl14_unicom``, ``vitl14_336px_unicom``.
+             You can check all the available options in ``self.constructors``
+            normalise_features: Set ``True`` to normalise output features
+            use_gradiend_ckpt: Whether to use gradient checkpointing inside VisionTransformer class.
+        """
         assert arch in self.constructors
         super(IExtractor, self).__init__()
 
         self.arch = arch
         self.normalise_features = normalise_features
 
-        self.model = self.constructors[arch](using_checkpoint=using_checkpoint)
+        self.model = self.constructors[arch](using_checkpoint=use_gradiend_ckpt)
 
         if weights is None:
             return

--- a/oml/models/vit_unicom/extractor.py
+++ b/oml/models/vit_unicom/extractor.py
@@ -70,7 +70,7 @@ class ViTUnicomExtractor(IExtractor):
         self.arch = arch
         self.normalise_features = normalise_features
 
-        self.model = self.constructors[arch](using_checkpoint)
+        self.model = self.constructors[arch](using_checkpoint=using_checkpoint)
 
         if weights is None:
             return

--- a/oml/models/vit_unicom/extractor.py
+++ b/oml/models/vit_unicom/extractor.py
@@ -14,20 +14,20 @@ from oml.models.vit_unicom.external.model import load  # type: ignore
 from oml.utils.misc_torch import normalise
 
 
-def unicom_vitb32() -> vision_transformer.VisionTransformer:  # type: ignore
-    return vision_transformer.build_model("ViT-B/32")  # type: ignore
+def unicom_vitb32(using_checkpoint: bool = True) -> vision_transformer.VisionTransformer:  # type: ignore
+    return vision_transformer.build_model("ViT-B/32", using_checkpoint=using_checkpoint)  # type: ignore
 
 
-def unicom_vitb16() -> vision_transformer.VisionTransformer:  # type: ignore
-    return vision_transformer.build_model("ViT-B/16")  # type: ignore
+def unicom_vitb16(using_checkpoint: bool = True) -> vision_transformer.VisionTransformer:  # type: ignore
+    return vision_transformer.build_model("ViT-B/16", using_checkpoint=using_checkpoint)  # type: ignore
 
 
-def unicom_vitl14() -> vision_transformer.VisionTransformer:  # type: ignore
-    return vision_transformer.build_model("ViT-L/14")  # type: ignore
+def unicom_vitl14(using_checkpoint: bool = True) -> vision_transformer.VisionTransformer:  # type: ignore
+    return vision_transformer.build_model("ViT-L/14", using_checkpoint=using_checkpoint)  # type: ignore
 
 
-def unicom_vitl14_336px() -> vision_transformer.VisionTransformer:  # type: ignore
-    return vision_transformer.build_model("ViT-L/14@336px")  # type: ignore
+def unicom_vitl14_336px(using_checkpoint: bool = True) -> vision_transformer.VisionTransformer:  # type: ignore
+    return vision_transformer.build_model("ViT-L/14@336px", using_checkpoint=using_checkpoint)  # type: ignore
 
 
 class ViTUnicomExtractor(IExtractor):
@@ -57,14 +57,20 @@ class ViTUnicomExtractor(IExtractor):
         },
     }
 
-    def __init__(self, weights: Optional[Union[Path, str]], arch: str, normalise_features: bool):
+    def __init__(
+        self,
+        weights: Optional[Union[Path, str]],
+        arch: str,
+        normalise_features: bool,
+        using_checkpoint: bool = True
+    ):
         assert arch in self.constructors
         super(IExtractor, self).__init__()
 
         self.arch = arch
         self.normalise_features = normalise_features
 
-        self.model = self.constructors[arch]()
+        self.model = self.constructors[arch](using_checkpoint)
 
         if weights is None:
             return

--- a/tests/test_oml/test_models/test_models_creation.py
+++ b/tests/test_oml/test_models/test_models_creation.py
@@ -51,6 +51,7 @@ def test_extractor(constructor: IExtractor, args: Dict[str, Any]) -> None:
     assert torch.allclose(features1, features2)
 
 
+@pytest.mark.long
 @pytest.mark.parametrize(
     "constructor,args",
     [


### PR DESCRIPTION
- [x] I've checked contribution [guide](https://open-metric-learning.readthedocs.io/en/latest/oml/contributing.html).

This PR fixes an error which was first discovered in #592 about exporting `ViTUnicomExtractor` to ONNX. The fix is simple but there is a question - is it enough to pass only `using_checkpoint` param or we can pass arbitrary params as `**kwargs` into `VisionTransformer` class? Also, do we need to test vitb16_unicom, vitl14_unicom and vitl14_336px_unicom or is it enough to test only one vitb32_unicom? 