### PR TITLE
A few optimizations that speedup training

### DIFF
--- a/oml/miners/inbatch_hard_tri.py
+++ b/oml/miners/inbatch_hard_tri.py
@@ -57,7 +57,7 @@ class HardTripletsMiner(ITripletsMinerInBatch):
 
         """
 
-        labels = torch.IntTensor(labels)
+        labels = torch.tensor(labels)
 
         # Ensure labels are a torch tensor
         labels = labels.to(distmat.device)

--- a/oml/miners/inbatch_hard_tri.py
+++ b/oml/miners/inbatch_hard_tri.py
@@ -67,24 +67,22 @@ class HardTripletsMiner(ITripletsMinerInBatch):
         label_equal = labels.unsqueeze(0) == labels.unsqueeze(1)  # Shape [batch_size, batch_size]
         label_not_equal = ~label_equal
 
-        label_equal.fill_diagonal_(False)
-
         # Get the hardest positives: argmax over the distance matrix where labels match (i.e. hardest positive)
         dist_pos = distmat.clone()
-        dist_pos[~label_equal] = -float("inf")  # Set non-positives to -inf
+        dist_pos[label_not_equal] = -float("inf")  # Set non-positives to -inf
         hardest_pos_idx = torch.argmax(dist_pos, dim=1)
 
         # Get the hardest negatives: argmin over the distance matrix where labels don't match (i.e. hardest negative)
         dist_neg = distmat.clone()
-        dist_neg[~label_not_equal] = float("inf")  # Set non-negatives to +inf
+        dist_neg[label_equal] = float("inf")  # Set non-negatives to +inf
         hardest_neg_idx = torch.argmin(dist_neg, dim=1)
 
         # Return anchor indices, positive indices, and negative indices
-        ids_anchor = torch.arange(batch_size, device=distmat.device)
+        ids_anchor = list(range(batch_size))
         ids_pos = hardest_pos_idx
         ids_neg = hardest_neg_idx
 
-        return ids_anchor.cpu().tolist(), ids_pos.cpu().tolist(), ids_neg.cpu().tolist()
+        return ids_anchor, ids_pos.cpu().tolist(), ids_neg.cpu().tolist()
 
 
 __all__ = ["HardTripletsMiner"]

--- a/oml/miners/inbatch_hard_tri.py
+++ b/oml/miners/inbatch_hard_tri.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import numpy as np
+import torch
 from torch import Tensor
 
 from oml.interfaces.miners import ITripletsMinerInBatch, TTripletsIds

--- a/oml/miners/inbatch_hard_tri.py
+++ b/oml/miners/inbatch_hard_tri.py
@@ -1,11 +1,9 @@
 from typing import List
 
-import numpy as np
 import torch
 from torch import Tensor
 
 from oml.interfaces.miners import ITripletsMinerInBatch, TTripletsIds
-from oml.utils.misc import find_value_ids
 from oml.utils.misc_torch import pairwise_dist
 
 

--- a/oml/miners/inbatch_hard_tri.py
+++ b/oml/miners/inbatch_hard_tri.py
@@ -57,24 +57,35 @@ class HardTripletsMiner(ITripletsMinerInBatch):
                 ``(anchor, positive, negative)``
 
         """
-        ids_all = set(range(len(labels)))
 
-        ids_anchor, ids_pos, ids_neg = [], [], []
+        labels = torch.IntTensor(labels)
 
-        for i_anch, label in enumerate(labels):
-            ids_label = set(find_value_ids(it=labels, value=label))
+        # Ensure labels are a torch tensor
+        labels = labels.to(distmat.device)
 
-            ids_pos_cur = np.array(list(ids_label - {i_anch}), int)
-            ids_neg_cur = np.array(list(ids_all - ids_label), int)
+        batch_size = labels.size(0)
 
-            i_pos = ids_pos_cur[distmat[i_anch, ids_pos_cur].argmax()]
-            i_neg = ids_neg_cur[distmat[i_anch, ids_neg_cur].argmin()]
+        label_equal = labels.unsqueeze(0) == labels.unsqueeze(1)  # Shape [batch_size, batch_size]
+        label_not_equal = ~label_equal
 
-            ids_anchor.append(i_anch)
-            ids_pos.append(i_pos)
-            ids_neg.append(i_neg)
+        label_equal.fill_diagonal_(False)
 
-        return ids_anchor, ids_pos, ids_neg
+        # Get the hardest positives: argmax over the distance matrix where labels match (i.e. hardest positive)
+        dist_pos = distmat.clone()
+        dist_pos[~label_equal] = -float('inf')  # Set non-positives to -inf
+        hardest_pos_idx = torch.argmax(dist_pos, dim=1)
+
+        # Get the hardest negatives: argmin over the distance matrix where labels don't match (i.e. hardest negative)
+        dist_neg = distmat.clone()
+        dist_neg[~label_not_equal] = float('inf')  # Set non-negatives to +inf
+        hardest_neg_idx = torch.argmin(dist_neg, dim=1)
+
+        # Return anchor indices, positive indices, and negative indices
+        ids_anchor = torch.arange(batch_size, device=distmat.device)
+        ids_pos = hardest_pos_idx
+        ids_neg = hardest_neg_idx
+
+        return ids_anchor.cpu().tolist(), ids_pos.cpu().tolist(), ids_neg.cpu().tolist()
 
 
 __all__ = ["HardTripletsMiner"]

--- a/oml/miners/inbatch_hard_tri.py
+++ b/oml/miners/inbatch_hard_tri.py
@@ -71,12 +71,12 @@ class HardTripletsMiner(ITripletsMinerInBatch):
 
         # Get the hardest positives: argmax over the distance matrix where labels match (i.e. hardest positive)
         dist_pos = distmat.clone()
-        dist_pos[~label_equal] = -float('inf')  # Set non-positives to -inf
+        dist_pos[~label_equal] = -float("inf")  # Set non-positives to -inf
         hardest_pos_idx = torch.argmax(dist_pos, dim=1)
 
         # Get the hardest negatives: argmin over the distance matrix where labels don't match (i.e. hardest negative)
         dist_neg = distmat.clone()
-        dist_neg[~label_not_equal] = float('inf')  # Set non-negatives to +inf
+        dist_neg[~label_not_equal] = float("inf")  # Set non-negatives to +inf
         hardest_neg_idx = torch.argmin(dist_neg, dim=1)
 
         # Return anchor indices, positive indices, and negative indices

--- a/oml/samplers/balance.py
+++ b/oml/samplers/balance.py
@@ -1,4 +1,4 @@
-from collections import Counter
+from collections import Counter, defaultdict
 from typing import Iterator, List, Union
 
 import numpy as np
@@ -67,7 +67,7 @@ class BalanceSampler(IBatchSampler):
 
         lbl2idx = defaultdict(list)
 
-        for idx, label in tqdm(enumerate(labels), total=len(labels)):
+        for idx, label in enumerate(labels):
             lbl2idx[label].append(idx)
 
         self.lbl2idx = dict(lbl2idx)

--- a/oml/samplers/balance.py
+++ b/oml/samplers/balance.py
@@ -64,7 +64,13 @@ class BalanceSampler(IBatchSampler):
         self._unq_labels = unq_labels
 
         labels = np.array(labels)
-        self.lbl2idx = {label: np.arange(len(labels))[labels == label].tolist() for label in set(labels)}
+
+        lbl2idx = defaultdict(list)
+
+        for idx, label in tqdm(enumerate(labels), total=len(labels)):
+            lbl2idx[label].append(idx)
+
+        self.lbl2idx = dict(lbl2idx)
 
         self._batches_in_epoch = len(self._unq_labels) // self.n_labels
 


### PR DESCRIPTION
Thanks for creating such a great project. 

I'm currently training on a rather large dataset (500+ GB) of audio data and have found a few optimizations that increase the pre-processing speed in the balance sampler from 10+ minutes down to ~15 seconds and changes to the sampling function to remove the for loop and use only torch functions, that made some pretty big changes for me (from 2 iterations/s to 3.5 iterations/s). 

Both changes produce exactly the same results as before.