### PR TITLE
Add new dataset converter for Revisited Oxford and Paris #302

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .vscode/*
 .env
 dataset
+data/
 lightning_logs/
 notebooks/
 dist/*

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ test_converters:
 	export PYTHONWARNINGS=ignore; python pipelines/datasets_converters/convert_cars.py    --dataset_root  data/CARS196 --no_bboxes
 	export PYTHONWARNINGS=ignore; python pipelines/datasets_converters/convert_inshop.py  --dataset_root  data/DeepFashion_InShop
 	export PYTHONWARNINGS=ignore; python pipelines/datasets_converters/convert_inshop.py  --dataset_root  data/DeepFashion_InShop --no_bboxes
+	export PYTHONWARNINGS=ignore; python pipelines/datasets_converters/convert_roxfordparis.py  --dataset_root data/roxfordparis
 
 .PHONY: static_checks
 static_checks:

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,8 @@ test_converters:
 	export PYTHONWARNINGS=ignore; python pipelines/datasets_converters/convert_cars.py    --dataset_root  data/CARS196 --no_bboxes
 	export PYTHONWARNINGS=ignore; python pipelines/datasets_converters/convert_inshop.py  --dataset_root  data/DeepFashion_InShop
 	export PYTHONWARNINGS=ignore; python pipelines/datasets_converters/convert_inshop.py  --dataset_root  data/DeepFashion_InShop --no_bboxes
-	export PYTHONWARNINGS=ignore; python pipelines/datasets_converters/convert_roxfordparis.py  --dataset_root data/roxfordparis
+	export PYTHONWARNINGS=ignore; python pipelines/datasets_converters/convert_roxford.py  --dataset_root data/roxford5k
+	export PYTHONWARNINGS=ignore; python pipelines/datasets_converters/convert_rparis.py  --dataset_root data/rparis6k
 
 .PHONY: static_checks
 static_checks:

--- a/pipelines/datasets_converters/README.md
+++ b/pipelines/datasets_converters/README.md
@@ -112,8 +112,8 @@ are split for training and the other 11,316 (60,502 images) labels are used for 
 [Dataset page.](https://www.kaggle.com/datasets/qiubit/roxfordparis/)
 
 The dataset combines Revisited Oxford (roxford5k) and Revisited Paris (rparis6k) for image retrieval benchmarking.
-It contains 11,454 images in total:
-- Revisited Oxford: 4,993 training/gallery images + 69 validation/query images
+It contains 11,455 images in total:
+- Revisited Oxford: 4,993 training/gallery images + 70 validation/query images
 - Revisited Paris: 6,322 training/gallery images + 70 validation/query images
 
 ```

--- a/pipelines/datasets_converters/README.md
+++ b/pipelines/datasets_converters/README.md
@@ -82,6 +82,7 @@ The dataset contains 52,712 images for 7,982 of clothing items.
 </details>
 
 
+
 <details>
 <summary>SOP (Stanford Online Products)</summary>
 <p>
@@ -105,28 +106,44 @@ are split for training and the other 11,316 (60,502 images) labels are used for 
 </p>
 </details>
 
+
+
 <details>
-<summary>Revisited Oxford and Paris</summary>
+<summary>Revisited Oxford</summary>
 <p>
 
 [Dataset page.](https://www.kaggle.com/datasets/qiubit/roxfordparis/)
 
-The dataset combines Revisited Oxford (roxford5k) and Revisited Paris (rparis6k) for image retrieval benchmarking.
-It contains 11,455 images in total:
-- Revisited Oxford: 4,993 training/gallery images + 70 validation/query images
-- Revisited Paris: 6,322 training/gallery images + 70 validation/query images
+The Revisited Oxford dataset contains 4,993 training/gallery images and 70 validation/query images.
 
 ```
-└── roxfordparis
+└── roxford5k
     ├── df.csv
-    ├── roxford5k
-    │   └── jpg
-    │       ├── all_souls_000000.jpg
-    │       └── ...  
-    └── rparis6k
-        └── jpg
-            ├── paris_defense_000000.jpg
-            └── ...
+    ├── gnd_roxford5k.pkl
+    └── jpg
+        ├── all_souls_000000.jpg
+        └── ...  
+```
+</p>
+</details>
+
+
+
+<details>
+<summary>Revisited Paris</summary>
+<p>
+
+[Dataset page.](https://www.kaggle.com/datasets/qiubit/roxfordparis/)
+
+The Revisited Paris dataset contains 6,322 training/gallery images and 70 validation/query images.
+
+```
+└── rparis6k
+    ├── df.csv
+    ├── gnd_rparis6k.pkl
+    └── jpg
+        ├── paris_defense_000000.jpg
+        └── ...
 ```
 </p>
 </details>

--- a/pipelines/datasets_converters/README.md
+++ b/pipelines/datasets_converters/README.md
@@ -105,5 +105,31 @@ are split for training and the other 11,316 (60,502 images) labels are used for 
 </p>
 </details>
 
+<details>
+<summary>Revisited Oxford and Paris</summary>
+<p>
+
+[Dataset page.](https://www.kaggle.com/datasets/qiubit/roxfordparis/)
+
+The dataset combines Revisited Oxford (roxford5k) and Revisited Paris (rparis6k) for image retrieval benchmarking.
+It contains 11,454 images in total:
+- Revisited Oxford: 4,993 training/gallery images + 69 validation/query images
+- Revisited Paris: 6,322 training/gallery images + 70 validation/query images
+
+```
+└── roxfordparis
+    ├── df.csv
+    ├── roxford5k
+    │   └── jpg
+    │       ├── all_souls_000000.jpg
+    │       └── ...  
+    └── rparis6k
+        └── jpg
+            ├── paris_defense_000000.jpg
+            └── ...
+```
+</p>
+</details>
+
 Note, you can find our pretrained checkpoints for these datasets in the
 [Models zoo](https://github.com/OML-Team/open-metric-learning#zoo).

--- a/pipelines/datasets_converters/convert_roxford.py
+++ b/pipelines/datasets_converters/convert_roxford.py
@@ -28,36 +28,30 @@ def load_pickle_file(file_path):
     return data
 
 
-def build_roxfordparis_df(dataset_root: Path) -> pd.DataFrame:
+def build_roxford_df(dataset_root: Path) -> pd.DataFrame:
     dataset_root = Path(dataset_root)
 
-    gnd_oxford_file = dataset_root / "roxford5k" / "gnd_roxford5k.pkl"
-    gnd_paris_file = dataset_root / "rparis6k" / "gnd_rparis6k.pkl"
-
-    for file in [gnd_oxford_file, gnd_paris_file]:
-        assert file.is_file(), f"File {file} does not exist."
+    gnd_oxford_file = dataset_root / "gnd_roxford5k.pkl"
+    assert gnd_oxford_file.is_file(), f"File {gnd_oxford_file} does not exist."
 
     oxford_data = load_pickle_file(gnd_oxford_file)
-    paris_data = load_pickle_file(gnd_paris_file)
 
     # We assume test data is in qimlist, train data in imlist
     oxford_imlist = oxford_data['imlist']
-    paris_imlist = paris_data['imlist']
     oxford_qimlist = oxford_data['qimlist']
-    paris_qimlist = paris_data['qimlist']
 
     # Extract category from image name (format: {category}_xxxxxx.jpg)
     def extract_category(name):
         return name.rsplit('_', 1)[0]
 
     # Get all categories
-    all_names = oxford_imlist + paris_imlist + oxford_qimlist + paris_qimlist
+    all_names = oxford_imlist + oxford_qimlist
     all_categories = [extract_category(name) for name in all_names]
     unique_categories = sorted(set(all_categories))
     category_to_label = {cat: idx + 1 for idx, cat in enumerate(unique_categories)}
 
-    def create_df(names, prefix, split, is_query, is_gallery):
-        paths = [f"{prefix}/jpg/{name}.jpg" for name in names]
+    def create_df(names, split, is_query, is_gallery):
+        paths = [f"jpg/{name}.jpg" for name in names]
         categories = [extract_category(name) for name in names]
         labels = [category_to_label[cat] for cat in categories]
 
@@ -71,12 +65,10 @@ def build_roxfordparis_df(dataset_root: Path) -> pd.DataFrame:
         })
 
     # Create dataframes
-    oxford_train_df = create_df(oxford_imlist, "roxford5k", "train", None, None)
-    paris_train_df = create_df(paris_imlist, "rparis6k", "train", None, None)
-    oxford_val_df = create_df(oxford_qimlist, "roxford5k", "validation", True, True)
-    paris_val_df = create_df(paris_qimlist, "rparis6k", "validation", True, True)
+    oxford_train_df = create_df(oxford_imlist, "train", None, None)
+    oxford_val_df = create_df(oxford_qimlist, "validation", True, True)
 
-    df = pd.concat([oxford_train_df, paris_train_df, oxford_val_df, paris_val_df], ignore_index=True)
+    df = pd.concat([oxford_train_df, oxford_val_df], ignore_index=True)
 
     # Sort by label
     df = df.sort_values(by="label", ascending=True).reset_index(drop=True)
@@ -87,11 +79,11 @@ def build_roxfordparis_df(dataset_root: Path) -> pd.DataFrame:
 
 
 def main() -> None:
-    print("Revisited Oxford and Paris dataset preparation started...")
+    print("Revisited Oxford dataset preparation started...")
     args = get_argparser().parse_args()
-    df = build_roxfordparis_df(args.dataset_root)
+    df = build_roxford_df(args.dataset_root)
     df.to_csv(args.dataset_root / "df.csv", index=None)
-    print("Revisited Oxford and Paris dataset preparation completed.")
+    print("Revisited Oxford dataset preparation completed.")
     print(f"DataFrame saved in {args.dataset_root}\n")
 
 

--- a/pipelines/datasets_converters/convert_roxfordparis.py
+++ b/pipelines/datasets_converters/convert_roxfordparis.py
@@ -1,0 +1,99 @@
+from argparse import ArgumentParser
+from pathlib import Path
+
+import pickle
+import pandas as pd
+
+from oml.const import (
+    CATEGORIES_COLUMN,
+    IS_GALLERY_COLUMN,
+    IS_QUERY_COLUMN,
+    LABELS_COLUMN,
+    PATHS_COLUMN,
+    SPLIT_COLUMN,
+)
+
+from oml.utils.dataframe_format import check_retrieval_dataframe_format
+
+
+def get_argparser() -> ArgumentParser:
+    parser = ArgumentParser()
+    parser.add_argument("--dataset_root", type=Path)
+    return parser
+
+
+def load_pickle_file(file_path):
+    with open(file_path, 'rb') as f:
+        data = pickle.load(f)
+    return data
+
+
+def build_roxfordparis_df(dataset_root: Path) -> pd.DataFrame:
+    dataset_root = Path(dataset_root)
+
+    gnd_oxford_file = dataset_root / "roxford5k" / "gnd_roxford5k.pkl"
+    gnd_paris_file = dataset_root / "rparis6k" / "gnd_rparis6k.pkl"
+
+    for file in [gnd_oxford_file, gnd_paris_file]:
+        assert file.is_file(), f"File {file} does not exist."
+
+    oxford_data = load_pickle_file(gnd_oxford_file)
+    paris_data = load_pickle_file(gnd_paris_file)
+
+    # We assume test data is in qimlist, train data in imlist
+    oxford_imlist = oxford_data['imlist']
+    paris_imlist = paris_data['imlist']
+    oxford_qimlist = oxford_data['qimlist']
+    paris_qimlist = paris_data['qimlist']
+
+    # Extract category from image name (format: {category}_xxxxxx.jpg)
+    def extract_category(name):
+        return name.rsplit('_', 1)[0]
+
+    # Get all categories
+    all_names = oxford_imlist + paris_imlist + oxford_qimlist + paris_qimlist
+    all_categories = [extract_category(name) for name in all_names]
+    unique_categories = sorted(set(all_categories))
+    category_to_label = {cat: idx for idx, cat in enumerate(unique_categories)}
+
+    def create_df(names, prefix, split, is_query, is_gallery):
+        paths = [f"{prefix}/jpg/{name}.jpg" for name in names]
+        categories = [extract_category(name) for name in names]
+        labels = [category_to_label[cat] for cat in categories]
+
+        return pd.DataFrame({
+            PATHS_COLUMN: paths,
+            LABELS_COLUMN: labels,
+            SPLIT_COLUMN: split,
+            IS_QUERY_COLUMN: is_query,
+            IS_GALLERY_COLUMN: is_gallery,
+            CATEGORIES_COLUMN: categories,
+        })
+
+    # Create dataframes
+    oxford_train_df = create_df(oxford_imlist, "roxford5k", "train", None, None)
+    paris_train_df = create_df(paris_imlist, "rparis6k", "train", None, None)
+    oxford_val_df = create_df(oxford_qimlist, "roxford5k", "validation", True, True)
+    paris_val_df = create_df(paris_qimlist, "rparis6k", "validation", True, True)
+
+    df = pd.concat([oxford_train_df, paris_train_df, oxford_val_df, paris_val_df], ignore_index=True)
+
+    # Sort by label
+    df = df.sort_values(by="label", ascending=True).reset_index(drop=True)
+
+    check_retrieval_dataframe_format(df, dataset_root=dataset_root)
+
+    return df
+
+
+def main() -> None:
+    print("Oxford5k dataset preparation started...")
+    args = get_argparser().parse_args()
+    df = build_roxfordparis_df(args.dataset_root)
+    df.to_csv(args.dataset_root / df.csv, index=None)
+    print("Oxford5k dataset preparation completed.")
+    print(f"DataFrame saved in {args.dataset_root}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/pipelines/datasets_converters/convert_roxfordparis.py
+++ b/pipelines/datasets_converters/convert_roxfordparis.py
@@ -54,7 +54,7 @@ def build_roxfordparis_df(dataset_root: Path) -> pd.DataFrame:
     all_names = oxford_imlist + paris_imlist + oxford_qimlist + paris_qimlist
     all_categories = [extract_category(name) for name in all_names]
     unique_categories = sorted(set(all_categories))
-    category_to_label = {cat: idx for idx, cat in enumerate(unique_categories)}
+    category_to_label = {cat: idx + 1 for idx, cat in enumerate(unique_categories)}
 
     def create_df(names, prefix, split, is_query, is_gallery):
         paths = [f"{prefix}/jpg/{name}.jpg" for name in names]
@@ -62,8 +62,8 @@ def build_roxfordparis_df(dataset_root: Path) -> pd.DataFrame:
         labels = [category_to_label[cat] for cat in categories]
 
         return pd.DataFrame({
-            PATHS_COLUMN: paths,
             LABELS_COLUMN: labels,
+            PATHS_COLUMN: paths,
             SPLIT_COLUMN: split,
             IS_QUERY_COLUMN: is_query,
             IS_GALLERY_COLUMN: is_gallery,
@@ -87,11 +87,11 @@ def build_roxfordparis_df(dataset_root: Path) -> pd.DataFrame:
 
 
 def main() -> None:
-    print("Oxford5k dataset preparation started...")
+    print("Revisited Oxford and Paris dataset preparation started...")
     args = get_argparser().parse_args()
     df = build_roxfordparis_df(args.dataset_root)
-    df.to_csv(args.dataset_root / df.csv, index=None)
-    print("Oxford5k dataset preparation completed.")
+    df.to_csv(args.dataset_root / "df.csv", index=None)
+    print("Revisited Oxford and Paris dataset preparation completed.")
     print(f"DataFrame saved in {args.dataset_root}\n")
 
 

--- a/pipelines/datasets_converters/convert_rparis.py
+++ b/pipelines/datasets_converters/convert_rparis.py
@@ -1,0 +1,91 @@
+from argparse import ArgumentParser
+from pathlib import Path
+
+import pickle
+import pandas as pd
+
+from oml.const import (
+    CATEGORIES_COLUMN,
+    IS_GALLERY_COLUMN,
+    IS_QUERY_COLUMN,
+    LABELS_COLUMN,
+    PATHS_COLUMN,
+    SPLIT_COLUMN,
+)
+
+from oml.utils.dataframe_format import check_retrieval_dataframe_format
+
+
+def get_argparser() -> ArgumentParser:
+    parser = ArgumentParser()
+    parser.add_argument("--dataset_root", type=Path)
+    return parser
+
+
+def load_pickle_file(file_path):
+    with open(file_path, 'rb') as f:
+        data = pickle.load(f)
+    return data
+
+
+def build_rparis_df(dataset_root: Path) -> pd.DataFrame:
+    dataset_root = Path(dataset_root)
+
+    gnd_paris_file = dataset_root / "gnd_rparis6k.pkl"
+    assert gnd_paris_file.is_file(), f"File {gnd_paris_file} does not exist."
+
+    paris_data = load_pickle_file(gnd_paris_file)
+
+    # We assume test data is in qimlist, train data in imlist
+    paris_imlist = paris_data['imlist']
+    paris_qimlist = paris_data['qimlist']
+
+    # Extract category from image name (format: {category}_xxxxxx.jpg)
+    def extract_category(name):
+        return name.rsplit('_', 1)[0]
+
+    # Get all categories
+    all_names = paris_imlist + paris_qimlist
+    all_categories = [extract_category(name) for name in all_names]
+    unique_categories = sorted(set(all_categories))
+    category_to_label = {cat: idx + 1 for idx, cat in enumerate(unique_categories)}
+
+    def create_df(names, split, is_query, is_gallery):
+        paths = [f"jpg/{name}.jpg" for name in names]
+        categories = [extract_category(name) for name in names]
+        labels = [category_to_label[cat] for cat in categories]
+
+        return pd.DataFrame({
+            LABELS_COLUMN: labels,
+            PATHS_COLUMN: paths,
+            SPLIT_COLUMN: split,
+            IS_QUERY_COLUMN: is_query,
+            IS_GALLERY_COLUMN: is_gallery,
+            CATEGORIES_COLUMN: categories,
+        })
+
+    # Create dataframes
+    paris_train_df = create_df(paris_imlist, "train", None, None)
+    paris_val_df = create_df(paris_qimlist, "validation", True, True)
+
+    df = pd.concat([paris_train_df, paris_val_df], ignore_index=True)
+
+    # Sort by label
+    df = df.sort_values(by="label", ascending=True).reset_index(drop=True)
+
+    check_retrieval_dataframe_format(df, dataset_root=dataset_root)
+
+    return df
+
+
+def main() -> None:
+    print("Revisited Paris dataset preparation started...")
+    args = get_argparser().parse_args()
+    df = build_rparis_df(args.dataset_root)
+    df.to_csv(args.dataset_root / "df.csv", index=None)
+    print("Revisited Paris dataset preparation completed.")
+    print(f"DataFrame saved in {args.dataset_root}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Overview

Closes #302

- This pull request introduces dataset converters for the Revisited Oxford (ROxford5k) and Revisited Paris (RParis6k) benchmarks.  

- It converts raw datasets into the required `df.csv` format, including the following fields:
  - `label`
  - `path`
  - `split`
  - `is_query`
  - `is_gallery`
  - `category`

- Note: Bounding boxes (bbox) are not included for all images, since only query images provide bbox annotations in these datasets. Therefore, `df_with_bboxes.csv` cannot be constructed.

---

## Preview

<img width="750" height="180" alt="image" src="https://github.com/user-attachments/assets/875c3db5-8e11-49f6-9db2-3cd6e5a557ec" />

<p align="center"><em>Example of the generated CSV format for ROxford5k.</em></p>

<br>

<img width="750" height="180" alt="image" src="https://github.com/user-attachments/assets/e0debeee-3763-437c-ad29-4790874fc696" />

<p align="center"><em>Example of the generated CSV format for RParis6k.</em></p>

---

## Checklist

- [x] I've checked contribution [guide](https://open-metric-learning.readthedocs.io/en/latest/oml/contributing.html).  
- [x] Code follows project structure and style. 
- [x] Dataset format is compatible with OML pipelines.

---

## Feedback

Welcome feedback and suggestions!